### PR TITLE
Link leaderboard wallets to block explorer

### DIFF
--- a/web/src/components/leader/leaderRow.tsx
+++ b/web/src/components/leader/leaderRow.tsx
@@ -1,4 +1,5 @@
 import useConnectWallet from "@/hooks/useConnectWallet";
+import config from "@/config";
 import { Leader } from "@/types";
 import { combineClass } from "@/utils/combineClass";
 import Button from "../themed/button";
@@ -27,9 +28,14 @@ export default function LeaderRow({ data }: { data?: Leader }) {
     <tr className="hover:bg-9blueLight/50">
       <td className={combineClass(cellStyle)}>{data.ranking}</td>
       <td className={combineClass(cellStyle)}>
-        <span className="block w-[100px] truncate sm:w-[160px] lg:w-full">
+        <a
+          className="block w-[100px] truncate sm:w-[160px] lg:w-full"
+          href={`${config.destinationChain.blockExplorers![0].url}/address/${data.wallet}`}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
           {data.wallet}
-        </span>
+        </a>
       </td>
       <td className={combineClass(cellStyle)}>{data.scoring}</td>
       {/* <td className={combineClass(cellStyle)}></td> */}


### PR DESCRIPTION
## Summary
- link leaderboard wallet addresses in the leaderboard view to the configured block explorer
- open the wallet link in a new tab with noopener/noreferrer attributes for security

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69090e79e34c832bb1a6daa271e94168