### PR TITLE
test: repair outcome id cross-check

### DIFF
--- a/tests/generate-id.test.ts
+++ b/tests/generate-id.test.ts
@@ -1,16 +1,22 @@
-import assert from 'assert';
-import { generateOutcomeId } from '../web/src/utils/generateId';
-import { exec } from "child_process";
-import { describe, it } from "node:test"
-import { promisify } from 'util';
+import { strict as assert } from "node:assert";
+import { execFile } from "node:child_process";
+import { test } from "node:test";
+import { promisify } from "node:util";
 
-describe('Node,js and Go id generation should be same', async () => {
-    const name = 'Yes'
-    const seed = 2429095232877049
-    const command = `go run scripts/generate-id.go ${name} ${seed}`;
-    const getGoId = promisify(exec)
-    const { stdout } = await getGoId(command)
-    const stdoutArr = stdout.trim().split(',')
-    const generatedGoId = stdoutArr[stdoutArr.length - 1]
-    assert.equal(generatedGoId, generateOutcomeId(name, seed), 'ids have to be equal')
-})
+import { generateOutcomeId } from "../web/src/utils/generateId";
+
+const getGoId = promisify(execFile);
+
+test("Go and TypeScript outcome ID generation match", async () => {
+  const name = "Yes";
+  const seed = 2429095232877049;
+  const { stdout } = await getGoId("go", [
+    "run",
+    "./scripts/outcome-id",
+    name,
+    seed.toString(),
+  ]);
+  const generatedGoId = stdout.trim();
+
+  assert.equal(generatedGoId, generateOutcomeId(name, seed));
+});


### PR DESCRIPTION
## Summary
- update the cross-language outcome ID test to use the existing `scripts/outcome-id` Go command
- convert the async suite body into a real `node:test` test case so failures exit nonzero
- use `execFile` with argv instead of shell interpolation

## Verification
- `pnpm run test:ids`
- `go test ./scripts/outcome-id`