### PR TITLE
Add DRAM 15min shortterm market, delist SpaceX

### DIFF
--- a/web/public/images/tokens/dram.svg
+++ b/web/public/images/tokens/dram.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <g stroke="#1F2937" stroke-width="2.4" stroke-linecap="round">
+    <path d="M7 17h5M7 24h5M7 31h5M41 17h-5M41 24h-5M41 31h-5"/>
+  </g>
+  <rect x="12" y="12" width="24" height="24" rx="3" fill="#1F2937"/>
+  <circle cx="17" cy="17" r="1.7" fill="#F9FAFB"/>
+  <rect x="18.5" y="20.5" width="11" height="7" rx="1.4" fill="none" stroke="#F9FAFB" stroke-width="1.6"/>
+</svg>

--- a/web/src/config/app.ts
+++ b/web/src/config/app.ts
@@ -9,6 +9,7 @@ import OIL from "#/images/tokens/oil.png";
 import CBRS from "#/images/tokens/cbrs.svg";
 import SPACEX from "#/images/tokens/spacex.svg";
 import IBM from "#/images/tokens/ibm.svg";
+import DRAM from "#/images/tokens/dram.svg";
 import { StaticImageData } from "next/image";
 enum InfraMarketState {
   Callable,
@@ -126,7 +127,7 @@ const simpleMarkets = {
     periods: ["15mins"],
     openHours: ["00:00", "23:59"],
     tz: "UTC",
-    listed: true,
+    listed: false,
   },
   xyzibm: {
     slug: "xyzibm",
@@ -139,6 +140,18 @@ const simpleMarkets = {
     openHours: ["00:00", "23:59"],
     tz: "America/New_York",
     listed: false,
+  },
+  xyzdram: {
+    slug: "xyzdram",
+    logo: DRAM,
+    title: "DRAM",
+    tabTitle: "DRAM",
+    openDays: [0, 1, 2, 3, 4, 5, 6],
+    decimals: 3,
+    periods: ["15mins"],
+    openHours: ["00:00", "23:59"],
+    tz: "UTC",
+    listed: true,
   },
   paxg: {
     slug: "paxg",

--- a/web/src/config/app.ts
+++ b/web/src/config/app.ts
@@ -144,7 +144,7 @@ const simpleMarkets = {
   xyzdram: {
     slug: "xyzdram",
     logo: DRAM,
-    title: "DRAM",
+    title: "DRAM Memory ETF",
     tabTitle: "DRAM",
     openDays: [0, 1, 2, 3, 4, 5, 6],
     decimals: 3,


### PR DESCRIPTION
## Summary
Adds the Hyperliquid `xyz:DRAM` builder asset as a 15-minute shortterm price market and delists SpaceX. Follows the repo's own [`agent-skills/adding-shortterm-markets.md`](agent-skills/adding-shortterm-markets.md) workflow.

## Changes
- **Add DRAM (`xyzdram`)** to `simpleMarkets` in `web/src/config/app.ts` — `periods: ["15mins"]`, 24/7 UTC (`openDays` all 7, `openHours` `00:00–23:59`), `decimals: 3`, `listed: true`. Matches the existing `xyz:` builder-asset convention (`xyzcbrs`, `xyzspcx`, `xyzibm`).
- **New logo** `web/public/images/tokens/dram.svg` — a memory-chip icon in the same 48×48 style as `cbrs.svg`.
- **Delist SpaceX** — `xyzspcx.listed` set `true → false` (config retained; hidden from the UI nav per the skill's documented `listed` toggle).

No schema/category changes needed — `"15mins"` is already in the `simpleMarketSchema` period union.

## Notes / follow-ups
- **Backend prerequisite (not in this PR):** the frontend config only makes the tab appear. For a live DRAM market to render, the cron (`create-price-market.rc`) must create DPPM markets with `priceMetadata.baseAsset = "DRAM"` and category `"15mins"`, and the Price Oracle must support a DRAM feed.
- **Logo** is a generic chip icon (DRAM has no single brand mark) — swap in a preferred image at the same path if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)