### PR TITLE
Fix short-term market chart: load time, ordering, and render artifacts

### DIFF
--- a/cmd/graphql.ethereum/graph/generated.go
+++ b/cmd/graphql.ethereum/graph/generated.go
@@ -43,6 +43,7 @@ type Config struct {
 type ResolverRoot interface {
 	Activity() ActivityResolver
 	AssetMetadata() AssetMetadataResolver
+	AssetPricePoint() AssetPricePointResolver
 	Campaign() CampaignResolver
 	Changelog() ChangelogResolver
 	Claim() ClaimResolver
@@ -88,6 +89,12 @@ type ComplexityRoot struct {
 		Name                  func(childComplexity int) int
 		Price                 func(childComplexity int) int
 		PriceCreatedAt        func(childComplexity int) int
+	}
+
+	AssetPricePoint struct {
+		Amount    func(childComplexity int) int
+		CreatedAt func(childComplexity int) int
+		Id        func(childComplexity int) int
 	}
 
 	Campaign struct {
@@ -225,6 +232,7 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
+		AssetPrices               func(childComplexity int, base string, from int, until int) int
 		Assets                    func(childComplexity int) int
 		AssetsDeltaHour           func(childComplexity int) int
 		CampaignByID              func(childComplexity int, id string) int
@@ -285,6 +293,9 @@ type AssetMetadataResolver interface {
 	PriceCreatedAt(ctx context.Context, obj *types.AssetMetadata) (int, error)
 
 	HourAgoPriceCreatedAt(ctx context.Context, obj *types.AssetMetadata) (int, error)
+}
+type AssetPricePointResolver interface {
+	CreatedAt(ctx context.Context, obj *types.AssetPricePoint) (int, error)
 }
 type CampaignResolver interface {
 	Name(ctx context.Context, obj *types.Campaign) (string, error)
@@ -375,6 +386,7 @@ type QueryResolver interface {
 	TotalPnL(ctx context.Context, address string, fromTs *int, untilTs *int) (*types.Pnl, error)
 	GetFinalPrice(ctx context.Context, symbol string, ending int) (string, error)
 	AssetsDeltaHour(ctx context.Context) ([]*types.AssetMetadata, error)
+	AssetPrices(ctx context.Context, base string, from int, until int) ([]types.AssetPricePoint, error)
 }
 type SettingsResolver interface {
 	Refererr(ctx context.Context, obj *types.Settings) (*string, error)
@@ -559,6 +571,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AssetMetadata.PriceCreatedAt(childComplexity), true
+
+	case "AssetPricePoint.amount":
+		if e.complexity.AssetPricePoint.Amount == nil {
+			break
+		}
+
+		return e.complexity.AssetPricePoint.Amount(childComplexity), true
+
+	case "AssetPricePoint.createdAt":
+		if e.complexity.AssetPricePoint.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.AssetPricePoint.CreatedAt(childComplexity), true
+
+	case "AssetPricePoint.id":
+		if e.complexity.AssetPricePoint.Id == nil {
+			break
+		}
+
+		return e.complexity.AssetPricePoint.Id(childComplexity), true
 
 	case "Campaign.banners":
 		if e.complexity.Campaign.Banners == nil {
@@ -1185,6 +1218,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Profile.WalletAddress(childComplexity), true
+
+	case "Query.assetPrices":
+		if e.complexity.Query.AssetPrices == nil {
+			break
+		}
+
+		args, err := ec.field_Query_assetPrices_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.AssetPrices(childComplexity, args["base"].(string), args["from"].(int), args["until"].(int)), true
 
 	case "Query.assets":
 		if e.complexity.Query.Assets == nil {
@@ -2367,6 +2412,39 @@ func (ec *executionContext) field_Query___type_args(ctx context.Context, rawArgs
 		}
 	}
 	args["name"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_assetPrices_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["base"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("base"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["base"] = arg0
+	var arg1 int
+	if tmp, ok := rawArgs["from"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("from"))
+		arg1, err = ec.unmarshalNInt2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["from"] = arg1
+	var arg2 int
+	if tmp, ok := rawArgs["until"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("until"))
+		arg2, err = ec.unmarshalNInt2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["until"] = arg2
 	return args, nil
 }
 
@@ -4009,6 +4087,138 @@ func (ec *executionContext) _AssetMetadata_hourAgoPriceCreatedAt(ctx context.Con
 func (ec *executionContext) fieldContext_AssetMetadata_hourAgoPriceCreatedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "AssetMetadata",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AssetPricePoint_id(ctx context.Context, field graphql.CollectedField, obj *types.AssetPricePoint) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AssetPricePoint_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Id, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt2int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AssetPricePoint_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AssetPricePoint",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AssetPricePoint_amount(ctx context.Context, field graphql.CollectedField, obj *types.AssetPricePoint) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AssetPricePoint_amount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Amount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(float64)
+	fc.Result = res
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AssetPricePoint_amount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AssetPricePoint",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AssetPricePoint_createdAt(ctx context.Context, field graphql.CollectedField, obj *types.AssetPricePoint) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AssetPricePoint_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.AssetPricePoint().CreatedAt(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AssetPricePoint_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AssetPricePoint",
 		Field:      field,
 		IsMethod:   true,
 		IsResolver: true,
@@ -9818,6 +10028,69 @@ func (ec *executionContext) fieldContext_Query_assetsDeltaHour(_ context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_assetPrices(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_assetPrices(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().AssetPrices(rctx, fc.Args["base"].(string), fc.Args["from"].(int), fc.Args["until"].(int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]types.AssetPricePoint)
+	fc.Result = res
+	return ec.marshalNAssetPricePoint2ᚕgithubᚗcomᚋfluidityᚑmoneyᚋ9livesᚗsoᚋlibᚋtypesᚐAssetPricePointᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_assetPrices(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_AssetPricePoint_id(ctx, field)
+			case "amount":
+				return ec.fieldContext_AssetPricePoint_amount(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_AssetPricePoint_createdAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type AssetPricePoint", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_assetPrices_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query___type(ctx, field)
 	if err != nil {
@@ -12555,6 +12828,86 @@ func (ec *executionContext) _AssetMetadata(ctx context.Context, sel ast.Selectio
 	return out
 }
 
+var assetPricePointImplementors = []string{"AssetPricePoint"}
+
+func (ec *executionContext) _AssetPricePoint(ctx context.Context, sel ast.SelectionSet, obj *types.AssetPricePoint) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, assetPricePointImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AssetPricePoint")
+		case "id":
+			out.Values[i] = ec._AssetPricePoint_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "amount":
+			out.Values[i] = ec._AssetPricePoint_amount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "createdAt":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._AssetPricePoint_createdAt(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var campaignImplementors = []string{"Campaign"}
 
 func (ec *executionContext) _Campaign(ctx context.Context, sel ast.SelectionSet, obj *types.Campaign) graphql.Marshaler {
@@ -15194,6 +15547,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "assetPrices":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_assetPrices(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "__type":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Query___type(ctx, field)
@@ -15930,6 +16305,54 @@ func (ec *executionContext) marshalNAssetMetadata2ᚕᚖgithubᚗcomᚋfluidity�
 	return ret
 }
 
+func (ec *executionContext) marshalNAssetPricePoint2githubᚗcomᚋfluidityᚑmoneyᚋ9livesᚗsoᚋlibᚋtypesᚐAssetPricePoint(ctx context.Context, sel ast.SelectionSet, v types.AssetPricePoint) graphql.Marshaler {
+	return ec._AssetPricePoint(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNAssetPricePoint2ᚕgithubᚗcomᚋfluidityᚑmoneyᚋ9livesᚗsoᚋlibᚋtypesᚐAssetPricePointᚄ(ctx context.Context, sel ast.SelectionSet, v []types.AssetPricePoint) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNAssetPricePoint2githubᚗcomᚋfluidityᚑmoneyᚋ9livesᚗsoᚋlibᚋtypesᚐAssetPricePoint(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interface{}) (bool, error) {
 	res, err := graphql.UnmarshalBoolean(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -16231,6 +16654,21 @@ func (ec *executionContext) marshalNCommentInvestment2ᚕᚖgithubᚗcomᚋfluid
 	return ret
 }
 
+func (ec *executionContext) unmarshalNFloat2float64(ctx context.Context, v interface{}) (float64, error) {
+	res, err := graphql.UnmarshalFloatContext(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNFloat2float64(ctx context.Context, sel ast.SelectionSet, v float64) graphql.Marshaler {
+	res := graphql.MarshalFloatContext(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return graphql.WrapContextMarshaler(ctx, res)
+}
+
 func (ec *executionContext) unmarshalNID2string(ctx context.Context, v interface{}) (string, error) {
 	res, err := graphql.UnmarshalID(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -16253,6 +16691,21 @@ func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v interface{}
 
 func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
 	res := graphql.MarshalInt(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNInt2int64(ctx context.Context, v interface{}) (int64, error) {
+	res, err := graphql.UnmarshalInt64(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInt2int64(ctx context.Context, sel ast.SelectionSet, v int64) graphql.Marshaler {
+	res := graphql.MarshalInt64(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")

--- a/cmd/graphql.ethereum/graph/schema.graphqls
+++ b/cmd/graphql.ethereum/graph/schema.graphqls
@@ -132,6 +132,14 @@ type Query {
   Return all assets with their lastest price and one hour ago prices
   """
   assetsDeltaHour: [AssetMetadata]!
+
+  """
+  Historical spot prices for an asset between two unix timestamps
+  (seconds), oldest first. Returns at most the most recent 5000 points
+  in the window. Used to seed price charts instantly over HTTP; the
+  websocket stream keeps them live afterwards.
+  """
+  assetPrices(base: String!, from: Int!, until: Int!): [AssetPricePoint!]!
 }
 
 type AssetMetadata {
@@ -140,6 +148,12 @@ type AssetMetadata {
   priceCreatedAt: Int!
   hourAgoPrice: String!
   hourAgoPriceCreatedAt: Int!
+}
+
+type AssetPricePoint {
+  id: Int!
+  amount: Float!
+  createdAt: Int!
 }
 
 type Pnl {

--- a/cmd/graphql.ethereum/graph/schema.resolvers.go
+++ b/cmd/graphql.ethereum/graph/schema.resolvers.go
@@ -116,6 +116,14 @@ func (r *assetMetadataResolver) HourAgoPriceCreatedAt(ctx context.Context, obj *
 	return int(obj.HourAgoPriceCreatedAt.Unix()), nil
 }
 
+// CreatedAt is the resolver for the createdAt field.
+func (r *assetPricePointResolver) CreatedAt(ctx context.Context, obj *types.AssetPricePoint) (int, error) {
+	if obj == nil {
+		return 0, fmt.Errorf("no asset price point")
+	}
+	return int(obj.CreatedAt.Unix()), nil
+}
+
 // Name is the resolver for the name field.
 func (r *campaignResolver) Name(ctx context.Context, obj *types.Campaign) (string, error) {
 	if obj == nil {
@@ -2196,6 +2204,30 @@ func (r *queryResolver) AssetsDeltaHour(ctx context.Context) ([]*types.AssetMeta
 	return assets, nil
 }
 
+// AssetPrices is the resolver for the assetPrices field.
+func (r *queryResolver) AssetPrices(ctx context.Context, base string, from int, until int) ([]types.AssetPricePoint, error) {
+	var points []types.AssetPricePoint
+	// Most recent points in the window, capped, then flipped so the
+	// caller receives them oldest first.
+	err := r.DB.Raw(`
+	select id, amount, created_by as created_at
+	from (
+	    select id, amount, created_by
+	    from oracles_ninelives_prices_2
+	    where base = ?
+	    and created_by >= to_timestamp(?)
+	    and created_by <= to_timestamp(?)
+	    order by created_by desc
+	    limit 5000
+	) latest
+	order by created_by asc
+	`, strings.ToUpper(base), from, until).Scan(&points).Error
+	if err != nil {
+		return nil, fmt.Errorf("error getting asset prices: %w", err)
+	}
+	return points, nil
+}
+
 // Refererr is the resolver for the refererr field.
 func (r *settingsResolver) Refererr(ctx context.Context, obj *types.Settings) (*string, error) {
 	if obj == nil {
@@ -2209,6 +2241,9 @@ func (r *Resolver) Activity() ActivityResolver { return &activityResolver{r} }
 
 // AssetMetadata returns AssetMetadataResolver implementation.
 func (r *Resolver) AssetMetadata() AssetMetadataResolver { return &assetMetadataResolver{r} }
+
+// AssetPricePoint returns AssetPricePointResolver implementation.
+func (r *Resolver) AssetPricePoint() AssetPricePointResolver { return &assetPricePointResolver{r} }
 
 // Campaign returns CampaignResolver implementation.
 func (r *Resolver) Campaign() CampaignResolver { return &campaignResolver{r} }
@@ -2239,6 +2274,7 @@ func (r *Resolver) Settings() SettingsResolver { return &settingsResolver{r} }
 
 type activityResolver struct{ *Resolver }
 type assetMetadataResolver struct{ *Resolver }
+type assetPricePointResolver struct{ *Resolver }
 type campaignResolver struct{ *Resolver }
 type changelogResolver struct{ *Resolver }
 type claimResolver struct{ *Resolver }

--- a/cmd/websocket.database/backfill_test.go
+++ b/cmd/websocket.database/backfill_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestLoadRecentPrices runs against a real database when
+// SPN_TEST_TIMESCALE_URL is set, and is skipped otherwise. The table
+// must contain rows for at least one base.
+func TestLoadRecentPrices(t *testing.T) {
+	url := os.Getenv("SPN_TEST_TIMESCALE_URL")
+	if url == "" {
+		t.Skip("SPN_TEST_TIMESCALE_URL not set")
+	}
+	rows, err := loadRecentPrices(context.Background(), url)
+	if err != nil {
+		t.Fatalf("loadRecentPrices: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Fatal("no rows returned")
+	}
+	perBase := make(map[string]int)
+	lastPerBase := make(map[string]time.Time)
+	for i, row := range rows {
+		base, ok := row["base"].(string)
+		if !ok {
+			t.Fatalf("row %d: base is %T", i, row["base"])
+		}
+		if _, ok := row["id"].(int64); !ok {
+			t.Fatalf("row %d: id is %T", i, row["id"])
+		}
+		if _, ok := row["amount"].(float64); !ok {
+			t.Fatalf("row %d: amount is %T", i, row["amount"])
+		}
+		createdBy, ok := row["created_by"].(time.Time)
+		if !ok {
+			t.Fatalf("row %d: created_by is %T", i, row["created_by"])
+		}
+		if last, seen := lastPerBase[base]; seen && createdBy.Before(last) {
+			t.Fatalf("row %d: base %s out of order: %v before %v",
+				i, base, createdBy, last)
+		}
+		lastPerBase[base] = createdBy
+		perBase[base]++
+	}
+	for base, n := range perBase {
+		if n > PrivateSnapshotLookback {
+			t.Fatalf("base %s exceeds lookback cap: %d rows", base, n)
+		}
+	}
+	fmt.Printf("rows per base: %v\n", perBase)
+}

--- a/cmd/websocket.database/main.go
+++ b/cmd/websocket.database/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -25,6 +26,8 @@ import (
 	cdcPublication "github.com/Trendyol/go-pq-cdc/pq/publication"
 	cdcReplication "github.com/Trendyol/go-pq-cdc/pq/replication"
 	cdcSlot "github.com/Trendyol/go-pq-cdc/pq/slot"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
 const (
@@ -84,16 +87,24 @@ func (pb *partitionedBuffer) insert(partitionKey string, content map[string]any)
 	x.i++
 }
 
+// itemsInOrder returns the buffered items oldest first. rb.i is the
+// next write position, so once the ring has wrapped the slots from
+// rb.i onwards hold the oldest entries.
+func (rb *ringBuffer) itemsInOrder() []map[string]any {
+	start := rb.i % PrivateSnapshotLookback
+	out := make([]map[string]any, 0, PrivateSnapshotLookback)
+	for j := 0; j < PrivateSnapshotLookback; j++ {
+		if item := rb.items[(start+j)%PrivateSnapshotLookback]; item != nil {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
 func (pb *partitionedBuffer) allItems() []map[string]any {
 	var out []map[string]any
 	for _, rb := range pb.buffers {
-		snapshot := make([]map[string]any, PrivateSnapshotLookback)
-		copy(snapshot, rb.items[:])
-		for _, item := range snapshot {
-			if item != nil {
-				out = append(out, item)
-			}
-		}
+		out = append(out, rb.itemsInOrder()...)
 	}
 	return out
 }
@@ -103,6 +114,56 @@ func compareFmt(v1, v2 any) bool {
 		return true
 	}
 	return fmt.Sprintf("%v", v1) == fmt.Sprintf("%v", v2)
+}
+
+// loadRecentPrices fetches the most recent price rows per asset from
+// the database, oldest first, shaped like the CDC-decoded rows the
+// buffer normally receives. The ring buffer is memory-only, so
+// without this every restart of this process would leave snapshots
+// with no history until it re-accumulates from the live stream.
+func loadRecentPrices(ctx context.Context, timescaleUrl string) ([]map[string]any, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	db, err := sql.Open("pgx", timescaleUrl)
+	if err != nil {
+		return nil, fmt.Errorf("open: %w", err)
+	}
+	defer db.Close()
+	rows, err := db.QueryContext(ctx, `
+	select p.id, p.base, p.amount, p.created_by
+	from (select distinct base from `+PricesTable+`) b
+	cross join lateral (
+	    select id, base, amount, created_by
+	    from `+PricesTable+`
+	    where base = b.base
+	    order by created_by desc
+	    limit $1
+	) p
+	order by p.created_by asc
+	`, PrivateSnapshotLookback)
+	if err != nil {
+		return nil, fmt.Errorf("query: %w", err)
+	}
+	defer rows.Close()
+	var out []map[string]any
+	for rows.Next() {
+		var (
+			id        int64
+			base      string
+			amount    float64
+			createdBy time.Time
+		)
+		if err := rows.Scan(&id, &base, &amount, &createdBy); err != nil {
+			return nil, fmt.Errorf("scan: %w", err)
+		}
+		out = append(out, map[string]any{
+			"id":         id,
+			"base":       base,
+			"amount":     amount,
+			"created_by": createdBy,
+		})
+	}
+	return out, rows.Err()
 }
 
 func main() {
@@ -186,6 +247,21 @@ func main() {
 
 	dumpChan := make(chan dumpRequest)
 
+	// Seed the prices buffer from the database so snapshots are
+	// complete immediately after a restart. Failure is non-fatal: we
+	// fall back to accumulating from the live stream only. The CDC
+	// slot may re-deliver some backfilled rows; clients dedupe by id.
+	backfill, err := loadRecentPrices(masterCtx, config.PickTimescaleUrl())
+	if err != nil {
+		slog.Warn("failed to backfill prices from the database",
+			"err", err,
+		)
+	} else {
+		slog.Info("backfilled prices from the database",
+			"rows", len(backfill),
+		)
+	}
+
 	go func() {
 		bufferMsgsChan := make(chan TableContent, 100*60)
 		bufferCookie := broadcast.Subscribe(bufferMsgsChan)
@@ -194,6 +270,17 @@ func main() {
 		defer broadcast.Unsubscribe(bufferCookie)
 
 		buffer := make(map[string]*partitionedBuffer)
+
+		for _, row := range backfill {
+			pb := buffer[PricesTable]
+			if pb == nil {
+				pb = newPartitionedBuffer()
+				buffer[PricesTable] = pb
+			}
+			if base, ok := row[PricesPartitionKey]; ok {
+				pb.insert(fmt.Sprintf("%v", base), row)
+			}
+		}
 
 		for {
 			select {

--- a/cmd/websocket.database/main_test.go
+++ b/cmd/websocket.database/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import "testing"
+
+func TestPartitionedBufferOrderBeforeWrap(t *testing.T) {
+	pb := newPartitionedBuffer()
+	for j := 0; j < 10; j++ {
+		pb.insert("BTC", map[string]any{"seq": j})
+	}
+	items := pb.allItems()
+	if len(items) != 10 {
+		t.Fatalf("expected 10 items, got %d", len(items))
+	}
+	for j, item := range items {
+		if item["seq"] != j {
+			t.Fatalf("item %d out of order: got seq %v", j, item["seq"])
+		}
+	}
+}
+
+func TestPartitionedBufferOrderAfterWrap(t *testing.T) {
+	pb := newPartitionedBuffer()
+	total := PrivateSnapshotLookback + 500
+	for j := 0; j < total; j++ {
+		pb.insert("BTC", map[string]any{"seq": j})
+	}
+	items := pb.allItems()
+	if len(items) != PrivateSnapshotLookback {
+		t.Fatalf("expected %d items, got %d", PrivateSnapshotLookback, len(items))
+	}
+	first := total - PrivateSnapshotLookback
+	for j, item := range items {
+		if item["seq"] != first+j {
+			t.Fatalf("item %d out of order: got seq %v, want %d", j, item["seq"], first+j)
+		}
+	}
+}
+
+func TestPartitionedBufferOrderAtExactCapacity(t *testing.T) {
+	pb := newPartitionedBuffer()
+	for j := 0; j < PrivateSnapshotLookback; j++ {
+		pb.insert("BTC", map[string]any{"seq": j})
+	}
+	items := pb.allItems()
+	if len(items) != PrivateSnapshotLookback {
+		t.Fatalf("expected %d items, got %d", PrivateSnapshotLookback, len(items))
+	}
+	for j, item := range items {
+		if item["seq"] != j {
+			t.Fatalf("item %d out of order: got seq %v", j, item["seq"])
+		}
+	}
+}

--- a/lib/types/types.go
+++ b/lib/types/types.go
@@ -278,6 +278,12 @@ type (
 		HourAgoPrice          string    `json:"hourAgoPrice"`
 		HourAgoPriceCreatedAt time.Time `json:"hourAgoPriceCreatedAt"`
 	}
+
+	AssetPricePoint struct {
+		Id        int64     `json:"id"`
+		Amount    float64   `json:"amount"`
+		CreatedAt time.Time `json:"createdAt"`
+	}
 )
 
 const (

--- a/web/__tests__/mergePricePoints.test.ts
+++ b/web/__tests__/mergePricePoints.test.ts
@@ -1,0 +1,44 @@
+import mergePricePoints from "@/utils/mergePricePoints";
+import type { PricePoint } from "@/types";
+
+const point = (id: number, timestamp: number, price = id): PricePoint => ({
+  id,
+  timestamp,
+  price,
+});
+
+describe("mergePricePoints", () => {
+  test("sorts an initial snapshot", () => {
+    const merged = mergePricePoints(undefined, [
+      point(3, 300),
+      point(1, 100),
+      point(2, 200),
+    ]);
+    expect(merged.map((p) => p.id)).toEqual([1, 2, 3]);
+  });
+
+  test("appends an in-order live point without resorting", () => {
+    const previous = [point(1, 100), point(2, 200)];
+    const merged = mergePricePoints(previous, [point(3, 300)]);
+    expect(merged.map((p) => p.id)).toEqual([1, 2, 3]);
+  });
+
+  test("inserts an out-of-order live point at the right position", () => {
+    const previous = [point(1, 100), point(3, 300)];
+    const merged = mergePricePoints(previous, [point(2, 200)]);
+    expect(merged.map((p) => p.id)).toEqual([1, 2, 3]);
+  });
+
+  test("drops a duplicate delivery of the same row", () => {
+    const previous = [point(1, 100), point(2, 200)];
+    const merged = mergePricePoints(previous, [point(2, 200)]);
+    expect(merged.map((p) => p.id)).toEqual([1, 2]);
+  });
+
+  test("merges a late snapshot without losing newer live points", () => {
+    const live = [point(4, 400), point(5, 500)];
+    const snapshot = [point(1, 100), point(2, 200), point(3, 300)];
+    const merged = mergePricePoints(live, snapshot);
+    expect(merged.map((p) => p.id)).toEqual([1, 2, 3, 4, 5]);
+  });
+});

--- a/web/src/components/charts/assetPriceChart.tsx
+++ b/web/src/components/charts/assetPriceChart.tsx
@@ -87,7 +87,7 @@ export default function AssetPriceChart({
   ];
   const uniquePoints = Array.from(
     new Map(pointsData.map((p) => [p.timestamp, p])).values(),
-  );
+  ).sort((a, b) => a.timestamp - b.timestamp);
   if (!simple) {
     let divider;
     switch (true) {
@@ -193,9 +193,10 @@ export default function AssetPriceChart({
           dot={false}
           dataKey={"price"}
           zIndex={99}
-          type="monotone"
+          type="linear"
           stroke={priceIsAbove ? "#5dd341" : "#f96565"}
           strokeWidth={2}
+          isAnimationActive={false}
           name={symbol.toUpperCase()}
         />
         {simple ? (

--- a/web/src/components/charts/assetPriceChartWrapper.tsx
+++ b/web/src/components/charts/assetPriceChartWrapper.tsx
@@ -1,9 +1,12 @@
 import { PricePoint, SimpleCampaignDetail } from "@/types";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import AssetPriceChartMask from "./assetPriceChartMask";
 import AssetPriceChart from "./assetPriceChart";
 import { useState } from "react";
 import LiveTrades from "../trades";
+import config from "@/config";
+import mergePricePoints from "@/utils/mergePricePoints";
+import { requestAssetPrices } from "@/providers/graphqlClient";
 import { useWSForDetail } from "@/hooks/useWSForDetail";
 
 export default function PriceChartWrapper({
@@ -23,14 +26,35 @@ export default function PriceChartWrapper({
     previousData: campaignData,
     simple,
   });
+  const queryClient = useQueryClient();
   const { data: assetPrices, isLoading } = useQuery<PricePoint[]>({
     queryKey: ["assetPrices", symbol, starting, ending],
+    // Seed the chart over HTTP so it renders immediately; the
+    // websocket stream keeps it live afterwards.
     queryFn: async () => {
-      throw new Error(
-        "This function should be called. This query is being updated by websocket.",
+      const fetched = await requestAssetPrices(
+        symbol.toUpperCase(),
+        Math.floor(starting / 1000),
+        Math.ceil(Math.min(Date.now(), ending) / 1000),
       );
+      const decimals = config.simpleMarkets[symbol].decimals;
+      const points = (fetched ?? []).map((i) => ({
+        price: Number(i.amount.toFixed(decimals)),
+        id: i.id,
+        timestamp: i.createdAt * 1000,
+      }));
+      // Live points may have landed over the websocket while this
+      // request was in flight; never drop them.
+      const live = queryClient.getQueryData<PricePoint[]>([
+        "assetPrices",
+        symbol,
+        starting,
+        ending,
+      ]);
+      return mergePricePoints(live, points);
     },
-    enabled: false,
+    staleTime: Infinity,
+    retry: 1,
   });
 
   const [simpleChart, setSimpleChart] = useState(simple);

--- a/web/src/components/v2/chart.tsx
+++ b/web/src/components/v2/chart.tsx
@@ -1,6 +1,7 @@
 "use client";
 import config from "@/config";
 import { PricePoint, SimpleMarketKey } from "@/types";
+import { memo } from "react";
 import {
   ComposedChart,
   ResponsiveContainer,
@@ -13,12 +14,11 @@ import {
   ReferenceDot,
 } from "recharts";
 
-export default function AssetPriceChart({
+function AssetPriceChart({
   symbol,
   basePrice,
   starting,
   ending,
-  volume,
   assetPrices,
 }: {
   id: string;
@@ -26,7 +26,6 @@ export default function AssetPriceChart({
   basePrice: number;
   starting: number;
   ending: number;
-  volume: string;
   assetPrices: PricePoint[];
 }) {
   const chartHeight = 300;
@@ -84,7 +83,7 @@ export default function AssetPriceChart({
   ];
   const uniquePoints = Array.from(
     new Map(pointsData.map((p) => [p.timestamp, p])).values(),
-  );
+  ).sort((a, b) => a.timestamp - b.timestamp);
 
   const PulseDot = ({ cx, cy }: { cx: number; cy: number }) => {
     return (
@@ -173,7 +172,7 @@ export default function AssetPriceChart({
           shape={PulseDot}
         />
         <Area
-          type="monotone"
+          type="linear"
           dataKey="price"
           stroke="none"
           fill={priceIsAbove ? "#16A34A" : "#DC2828"}
@@ -185,9 +184,10 @@ export default function AssetPriceChart({
           dot={false}
           dataKey={"price"}
           zIndex={99}
-          type="monotone"
+          type="linear"
           stroke={priceIsAbove ? "#16A34A" : "#DC2828"}
           strokeWidth={2}
+          isAnimationActive={false}
           name={symbol.toUpperCase()}
         />
         <ReferenceLine
@@ -300,9 +300,10 @@ export default function AssetPriceChart({
           }}
         />
       </ComposedChart>
-      <span className="absolute inset-x-0 -bottom-1 block text-center text-xs text-neutral-400">
-        ${volume} Vol.
-      </span>
     </ResponsiveContainer>
   );
 }
+
+// Only re-render the plot when its own inputs change; trades update the
+// surrounding campaign object every few seconds and must not touch it.
+export default memo(AssetPriceChart);

--- a/web/src/components/v2/chartWrapper.tsx
+++ b/web/src/components/v2/chartWrapper.tsx
@@ -1,9 +1,12 @@
 import { PricePoint, SimpleCampaignDetail } from "@/types";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import AssetPriceChartMask from "./chartMask";
 import AssetPriceChart from "./chart";
 import LiveTrades from "./trades";
+import config from "@/config";
 import formatFusdc from "@/utils/format/formatUsdc";
+import mergePricePoints from "@/utils/mergePricePoints";
+import { requestAssetPrices } from "@/providers/graphqlClient";
 import { useWSForDetail } from "@/hooks/useWSForDetail";
 import { useWSForTrades } from "@/hooks/useWSForTrades";
 
@@ -29,14 +32,35 @@ export default function PriceChartWrapper({
     simple,
     isDpm: !!campaignData.isDpm,
   });
+  const queryClient = useQueryClient();
   const { data: assetPrices, isLoading } = useQuery<PricePoint[]>({
     queryKey: ["assetPrices", symbol, starting, ending],
+    // Seed the chart over HTTP so it renders immediately; the
+    // websocket stream keeps it live afterwards.
     queryFn: async () => {
-      throw new Error(
-        "This function should be called. This query is being updated by websocket.",
+      const fetched = await requestAssetPrices(
+        symbol.toUpperCase(),
+        Math.floor(starting / 1000),
+        Math.ceil(Math.min(Date.now(), ending) / 1000),
       );
+      const decimals = config.simpleMarkets[symbol].decimals;
+      const points = (fetched ?? []).map((i) => ({
+        price: Number(i.amount.toFixed(decimals)),
+        id: i.id,
+        timestamp: i.createdAt * 1000,
+      }));
+      // Live points may have landed over the websocket while this
+      // request was in flight; never drop them.
+      const live = queryClient.getQueryData<PricePoint[]>([
+        "assetPrices",
+        symbol,
+        starting,
+        ending,
+      ]);
+      return mergePricePoints(live, points);
     },
-    enabled: false,
+    staleTime: Infinity,
+    retry: 1,
   });
   const totalVolume = campaignData.odds
     ? Object.values(campaignData.odds).reduce((acc, v) => acc + Number(v), 0)
@@ -50,7 +74,6 @@ export default function PriceChartWrapper({
     <div className="relative">
       <AssetPriceChartMask simple={simple} campaignData={campaignData} />
       <AssetPriceChart
-        volume={formattedVolume}
         starting={starting}
         ending={ending}
         symbol={symbol}
@@ -58,6 +81,9 @@ export default function PriceChartWrapper({
         basePrice={+campaignData.priceMetadata.priceTargetForUp}
         id={campaignData.identifier}
       />
+      <span className="absolute inset-x-0 -bottom-1 block text-center text-xs text-neutral-400">
+        ${formattedVolume} Vol.
+      </span>
       <div className="absolute bottom-4 left-px z-[9] md:left-[-51px]">
         <LiveTrades campaignId={campaignData.identifier} />
       </div>

--- a/web/src/graffle/lives9/modules/methods-root.ts
+++ b/web/src/graffle/lives9/modules/methods-root.ts
@@ -627,6 +627,31 @@ export interface QueryMethods<$Context extends $$Utilities.Context> {
         >
     >
   >;
+  /**
+   * Historical spot prices for an asset between two unix timestamps
+   * (seconds), oldest first. Returns at most the most recent 5000 points
+   * in the window. Used to seed price charts instantly over HTTP; the
+   * websocket stream keeps them live afterwards.
+   */
+  assetPrices: $$Utilities.ClientTransports.PreflightCheck<
+    $Context,
+    <$SelectionSet>(
+      selectionSet: $$Utilities.Exact<
+        $SelectionSet,
+        $$SelectionSets.Query.assetPrices<$Context["scalars"]>
+      >,
+    ) => Promise<
+      (null | {}) &
+        $$Utilities.HandleOutputGraffleRootField<
+          $Context,
+          InferResult.OperationQuery<
+            { assetPrices: $SelectionSet },
+            $$Schema.Schema<$Context["scalars"]>
+          >,
+          "assetPrices"
+        >
+    >
+  >;
 }
 
 export interface MutationMethods<$Context extends $$Utilities.Context> {

--- a/web/src/graffle/lives9/modules/methods-select.ts
+++ b/web/src/graffle/lives9/modules/methods-select.ts
@@ -21,6 +21,7 @@ export interface $MethodsSelect {
   Query: Query;
   Mutation: Mutation;
   AssetMetadata: AssetMetadata;
+  AssetPricePoint: AssetPricePoint;
   Pnl: Pnl;
   Asset: Asset;
   UnclaimedCampaign: UnclaimedCampaign;
@@ -94,6 +95,15 @@ export interface AssetMetadata {
     selectionSet: $$Utilities.Exact<
       $SelectionSet,
       $$SelectionSets.AssetMetadata
+    >,
+  ): $SelectionSet;
+}
+
+export interface AssetPricePoint {
+  <$SelectionSet>(
+    selectionSet: $$Utilities.Exact<
+      $SelectionSet,
+      $$SelectionSets.AssetPricePoint
     >,
   ): $SelectionSet;
 }

--- a/web/src/graffle/lives9/modules/schema-driven-data-map.ts
+++ b/web/src/graffle/lives9/modules/schema-driven-data-map.ts
@@ -22,6 +22,8 @@ const Int = $$Scalar.Int;
 
 const Boolean = $$Scalar.Boolean;
 
+const Float = $$Scalar.Float;
+
 const ID = $$Scalar.ID;
 
 //
@@ -135,6 +137,14 @@ const AssetMetadata: $$Utilities.SchemaDrivenDataMap.OutputObject = {
     priceCreatedAt: {},
     hourAgoPrice: {},
     hourAgoPriceCreatedAt: {},
+  },
+};
+
+const AssetPricePoint: $$Utilities.SchemaDrivenDataMap.OutputObject = {
+  f: {
+    id: {},
+    amount: {},
+    createdAt: {},
   },
 };
 
@@ -736,6 +746,23 @@ const Query: $$Utilities.SchemaDrivenDataMap.OutputObject = {
     assetsDeltaHour: {
       // nt: AssetMetadata, <-- Assigned later to avoid potential circular dependency.
     },
+    assetPrices: {
+      a: {
+        base: {
+          nt: String,
+          it: [1],
+        },
+        from: {
+          nt: Int,
+          it: [1],
+        },
+        until: {
+          nt: Int,
+          it: [1],
+        },
+      },
+      // nt: AssetPricePoint, <-- Assigned later to avoid potential circular dependency.
+    },
   },
 };
 
@@ -1121,6 +1148,7 @@ Query.f[`unclaimedCampaigns`]!.nt = UnclaimedCampaign;
 Query.f[`assets`]!.nt = Asset;
 Query.f[`totalPnL`]!.nt = Pnl;
 Query.f[`assetsDeltaHour`]!.nt = AssetMetadata;
+Query.f[`assetPrices`]!.nt = AssetPricePoint;
 
 //
 //
@@ -1148,6 +1176,7 @@ const $schemaDrivenDataMap: $$Utilities.SchemaDrivenDataMap = {
     String,
     Int,
     Boolean,
+    Float,
     ID,
     Odds,
     PaymasterOperation,
@@ -1157,6 +1186,7 @@ const $schemaDrivenDataMap: $$Utilities.SchemaDrivenDataMap = {
     OutcomeInput,
     PriceMetadataInput,
     AssetMetadata,
+    AssetPricePoint,
     Pnl,
     Asset,
     UnclaimedCampaign,

--- a/web/src/graffle/lives9/modules/schema.ts
+++ b/web/src/graffle/lives9/modules/schema.ts
@@ -55,6 +55,7 @@ export namespace Schema {
       totalPnL: Query.totalPnL;
       getFinalPrice: Query.getFinalPrice;
       assetsDeltaHour: Query.assetsDeltaHour;
+      assetPrices: Query.assetPrices;
     };
   }
 
@@ -633,6 +634,38 @@ export namespace Schema {
       arguments: {};
       inlineType: [1, [0]];
       namedType: $$NamedTypes.$$AssetMetadata;
+    }
+
+    /**
+     * Historical spot prices for an asset between two unix timestamps
+     * (seconds), oldest first. Returns at most the most recent 5000 points
+     * in the window. Used to seed price charts instantly over HTTP; the
+     * websocket stream keeps them live afterwards.
+     */
+    export interface assetPrices extends $.OutputField {
+      name: "assetPrices";
+      arguments: {
+        base: {
+          kind: "InputField";
+          name: "base";
+          inlineType: [1];
+          namedType: $$NamedTypes.$$String;
+        };
+        from: {
+          kind: "InputField";
+          name: "from";
+          inlineType: [1];
+          namedType: $$NamedTypes.$$Int;
+        };
+        until: {
+          kind: "InputField";
+          name: "until";
+          inlineType: [1];
+          namedType: $$NamedTypes.$$Int;
+        };
+      };
+      inlineType: [1, [1]];
+      namedType: $$NamedTypes.$$AssetPricePoint;
     }
   }
 
@@ -1467,6 +1500,53 @@ export namespace Schema {
 
     export interface hourAgoPriceCreatedAt extends $.OutputField {
       name: "hourAgoPriceCreatedAt";
+      arguments: {};
+      inlineType: [1];
+      namedType: $$NamedTypes.$$Int;
+    }
+  }
+
+  //                                          AssetPricePoint
+  // --------------------------------------------------------------------------------------------------
+  //
+
+  export interface AssetPricePoint extends $.OutputObject {
+    name: "AssetPricePoint";
+    fields: {
+      __typename: AssetPricePoint.__typename;
+      id: AssetPricePoint.id;
+      amount: AssetPricePoint.amount;
+      createdAt: AssetPricePoint.createdAt;
+    };
+  }
+
+  export namespace AssetPricePoint {
+    export interface __typename extends $.OutputField {
+      name: "__typename";
+      arguments: {};
+      inlineType: [1];
+      namedType: {
+        kind: "__typename";
+        value: "AssetPricePoint";
+      };
+    }
+
+    export interface id extends $.OutputField {
+      name: "id";
+      arguments: {};
+      inlineType: [1];
+      namedType: $$NamedTypes.$$Int;
+    }
+
+    export interface amount extends $.OutputField {
+      name: "amount";
+      arguments: {};
+      inlineType: [1];
+      namedType: $$NamedTypes.$$Float;
+    }
+
+    export interface createdAt extends $.OutputField {
+      name: "createdAt";
       arguments: {};
       inlineType: [1];
       namedType: $$NamedTypes.$$Int;
@@ -3285,6 +3365,12 @@ export namespace Schema {
 
   export type Boolean = $.StandardTypes.Boolean;
 
+  //                                               Float
+  // --------------------------------------------------------------------------------------------------
+  //
+
+  export type Float = $.StandardTypes.Float;
+
   //                                                 ID
   // --------------------------------------------------------------------------------------------------
   //
@@ -3319,6 +3405,7 @@ export namespace Schema {
     export type $$Query = Query;
     export type $$Mutation = Mutation;
     export type $$AssetMetadata = AssetMetadata;
+    export type $$AssetPricePoint = AssetPricePoint;
     export type $$Pnl = Pnl;
     export type $$Asset = Asset;
     export type $$UnclaimedCampaign = UnclaimedCampaign;
@@ -3351,6 +3438,7 @@ export namespace Schema {
     export type $$String = String;
     export type $$Int = Int;
     export type $$Boolean = Boolean;
+    export type $$Float = Float;
     export type $$ID = ID;
   }
 }
@@ -3390,6 +3478,7 @@ export interface Schema<
     SettlementType: Schema.SettlementType;
     ActivityType: Schema.ActivityType;
     AssetMetadata: Schema.AssetMetadata;
+    AssetPricePoint: Schema.AssetPricePoint;
     Pnl: Schema.Pnl;
     Asset: Schema.Asset;
     UnclaimedCampaign: Schema.UnclaimedCampaign;
@@ -3415,6 +3504,7 @@ export interface Schema<
   };
   objects: {
     AssetMetadata: Schema.AssetMetadata;
+    AssetPricePoint: Schema.AssetPricePoint;
     Pnl: Schema.Pnl;
     Asset: Schema.Asset;
     UnclaimedCampaign: Schema.UnclaimedCampaign;
@@ -3440,12 +3530,13 @@ export interface Schema<
   };
   unions: {};
   interfaces: {};
-  scalarNamesUnion: "Odds" | "String" | "Int" | "Boolean" | "ID";
+  scalarNamesUnion: "Odds" | "String" | "Int" | "Boolean" | "Float" | "ID";
   scalars: {
     Odds: Schema.Odds;
     String: Schema.String;
     Int: Schema.Int;
     Boolean: Schema.Boolean;
+    Float: Schema.Float;
     ID: Schema.ID;
   };
   scalarRegistry: $Scalars;

--- a/web/src/graffle/lives9/modules/select.ts
+++ b/web/src/graffle/lives9/modules/select.ts
@@ -64,6 +64,13 @@ export namespace Select {
     $$Schema.Schema,
     $$Schema.Schema["allTypes"]["AssetMetadata"]
   >;
+  export type AssetPricePoint<
+    $SelectionSet extends $$SelectionSets.AssetPricePoint,
+  > = InferResult.OutputObjectLike<
+    $SelectionSet,
+    $$Schema.Schema,
+    $$Schema.Schema["allTypes"]["AssetPricePoint"]
+  >;
   export type Pnl<$SelectionSet extends $$SelectionSets.Pnl> =
     InferResult.OutputObjectLike<
       $SelectionSet,

--- a/web/src/graffle/lives9/modules/selection-sets.ts
+++ b/web/src/graffle/lives9/modules/selection-sets.ts
@@ -269,6 +269,14 @@ export interface Query<
   assetsDeltaHour?:
     | Query.assetsDeltaHour$Expanded<_$Scalars>
     | $Select.SelectAlias.SelectAlias<Query.assetsDeltaHour<_$Scalars>>;
+  /**
+   *
+   * Select the `assetPrices` field on the `Query` object. Its type is `AssetPricePoint` (a `OutputObject` kind of type).
+   *
+   */
+  assetPrices?:
+    | Query.assetPrices<_$Scalars>
+    | $Select.SelectAlias.SelectAlias<Query.assetPrices<_$Scalars>>;
 
   /**
    *
@@ -1322,6 +1330,47 @@ export namespace Query {
     _$Scalars extends $$Utilities.Schema.Scalar.Registry =
       $$Utilities.Schema.Scalar.Registry.Empty,
   > = $$Utilities.Simplify<assetsDeltaHour$SelectionSet<_$Scalars>>;
+
+  // --------------------------------------------------------------------------------------------------
+
+  export type assetPrices<
+    _$Scalars extends $$Utilities.Schema.Scalar.Registry =
+      $$Utilities.Schema.Scalar.Registry.Empty,
+  > = assetPrices$SelectionSet<_$Scalars>;
+
+  export interface assetPrices$SelectionSet<
+    _$Scalars extends $$Utilities.Schema.Scalar.Registry =
+      $$Utilities.Schema.Scalar.Registry.Empty,
+  >
+    extends $Select.Bases.Base, $NamedTypes.$AssetPricePoint<_$Scalars> {
+    /**
+     * Arguments for `assetPrices` field. All arguments are required so you must include this.
+     */
+    $: assetPrices$Arguments<_$Scalars>;
+  }
+
+  export interface assetPrices$Arguments<
+    _$Scalars extends $$Utilities.Schema.Scalar.Registry =
+      $$Utilities.Schema.Scalar.Registry.Empty,
+  > {
+    base: string;
+    from: number;
+    until: number;
+  }
+
+  // --- expanded ---
+
+  /**
+   *
+   * This is the "expanded" version of the `assetPrices` type. It is identical except for the fact
+   * that IDEs will display its contents (a union type) directly, rather than the name of this type.
+   * In some cases, this is a preferable DX, making the types easier to read for users.
+   *
+   */
+  export type assetPrices$Expanded<
+    _$Scalars extends $$Utilities.Schema.Scalar.Registry =
+      $$Utilities.Schema.Scalar.Registry.Empty,
+  > = $$Utilities.Simplify<assetPrices$SelectionSet<_$Scalars>>;
 }
 
 //                                              Mutation
@@ -2401,6 +2450,165 @@ export namespace AssetMetadata {
   > = $$Utilities.Simplify<
     | $Select.Indicator.NoArgsIndicator
     | hourAgoPriceCreatedAt$SelectionSet<_$Scalars>
+  >;
+}
+
+//                                          AssetPricePoint
+// --------------------------------------------------------------------------------------------------
+//
+
+// ----------------------------------------| Entrypoint Interface |
+
+export interface AssetPricePoint<
+  _$Scalars extends $$Utilities.Schema.Scalar.Registry =
+    $$Utilities.Schema.Scalar.Registry.Empty,
+>
+  extends $Select.Bases.ObjectLike {
+  /**
+   *
+   * Select the `id` field on the `AssetPricePoint` object. Its type is `Int` (a `ScalarStandard` kind of type).
+   *
+   */
+  id?:
+    | AssetPricePoint.id$Expanded<_$Scalars>
+    | $Select.SelectAlias.SelectAlias<AssetPricePoint.id<_$Scalars>>;
+  /**
+   *
+   * Select the `amount` field on the `AssetPricePoint` object. Its type is `Float` (a `ScalarStandard` kind of type).
+   *
+   */
+  amount?:
+    | AssetPricePoint.amount$Expanded<_$Scalars>
+    | $Select.SelectAlias.SelectAlias<AssetPricePoint.amount<_$Scalars>>;
+  /**
+   *
+   * Select the `createdAt` field on the `AssetPricePoint` object. Its type is `Int` (a `ScalarStandard` kind of type).
+   *
+   */
+  createdAt?:
+    | AssetPricePoint.createdAt$Expanded<_$Scalars>
+    | $Select.SelectAlias.SelectAlias<AssetPricePoint.createdAt<_$Scalars>>;
+
+  /**
+   *
+   * Inline fragments for field groups.
+   *
+   * Generally a niche feature. This can be useful for example to apply an `@include` directive to a subset of the
+   * selection set in turn allowing you to pass a variable to opt in/out of that selection during execution on the server.
+   *
+   * @see https://spec.graphql.org/draft/#sec-Inline-Fragments
+   *
+   */
+  ___?:
+    | AssetPricePoint$FragmentInline<_$Scalars>
+    | AssetPricePoint$FragmentInline<_$Scalars>[];
+
+  /**
+   *
+   * A meta field. Is the name of the type being selected.
+   *
+   * @see https://graphql.org/learn/queries/#meta-fields
+   *
+   */
+  __typename?:
+    | $Select.Indicator.NoArgsIndicator$Expanded
+    | $Select.SelectAlias.SelectAlias<$Select.Indicator.NoArgsIndicator>;
+}
+
+export interface AssetPricePoint$FragmentInline<
+  _$Scalars extends $$Utilities.Schema.Scalar.Registry =
+    $$Utilities.Schema.Scalar.Registry.Empty,
+>
+  extends
+    AssetPricePoint<_$Scalars>,
+    $Select.Directive.$Groups.InlineFragment.Fields {}
+
+// ----------------------------------------| Fields |
+
+export namespace AssetPricePoint {
+  export type id<
+    _$Scalars extends $$Utilities.Schema.Scalar.Registry =
+      $$Utilities.Schema.Scalar.Registry.Empty,
+  > = $Select.Indicator.NoArgsIndicator | id$SelectionSet<_$Scalars>;
+
+  export interface id$SelectionSet<
+    _$Scalars extends $$Utilities.Schema.Scalar.Registry =
+      $$Utilities.Schema.Scalar.Registry.Empty,
+  >
+    extends $Select.Bases.Base {}
+
+  // --- expanded ---
+
+  /**
+   *
+   * This is the "expanded" version of the `id` type. It is identical except for the fact
+   * that IDEs will display its contents (a union type) directly, rather than the name of this type.
+   * In some cases, this is a preferable DX, making the types easier to read for users.
+   *
+   */
+  export type id$Expanded<
+    _$Scalars extends $$Utilities.Schema.Scalar.Registry =
+      $$Utilities.Schema.Scalar.Registry.Empty,
+  > = $$Utilities.Simplify<
+    $Select.Indicator.NoArgsIndicator | id$SelectionSet<_$Scalars>
+  >;
+
+  // --------------------------------------------------------------------------------------------------
+
+  export type amount<
+    _$Scalars extends $$Utilities.Schema.Scalar.Registry =
+      $$Utilities.Schema.Scalar.Registry.Empty,
+  > = $Select.Indicator.NoArgsIndicator | amount$SelectionSet<_$Scalars>;
+
+  export interface amount$SelectionSet<
+    _$Scalars extends $$Utilities.Schema.Scalar.Registry =
+      $$Utilities.Schema.Scalar.Registry.Empty,
+  >
+    extends $Select.Bases.Base {}
+
+  // --- expanded ---
+
+  /**
+   *
+   * This is the "expanded" version of the `amount` type. It is identical except for the fact
+   * that IDEs will display its contents (a union type) directly, rather than the name of this type.
+   * In some cases, this is a preferable DX, making the types easier to read for users.
+   *
+   */
+  export type amount$Expanded<
+    _$Scalars extends $$Utilities.Schema.Scalar.Registry =
+      $$Utilities.Schema.Scalar.Registry.Empty,
+  > = $$Utilities.Simplify<
+    $Select.Indicator.NoArgsIndicator | amount$SelectionSet<_$Scalars>
+  >;
+
+  // --------------------------------------------------------------------------------------------------
+
+  export type createdAt<
+    _$Scalars extends $$Utilities.Schema.Scalar.Registry =
+      $$Utilities.Schema.Scalar.Registry.Empty,
+  > = $Select.Indicator.NoArgsIndicator | createdAt$SelectionSet<_$Scalars>;
+
+  export interface createdAt$SelectionSet<
+    _$Scalars extends $$Utilities.Schema.Scalar.Registry =
+      $$Utilities.Schema.Scalar.Registry.Empty,
+  >
+    extends $Select.Bases.Base {}
+
+  // --- expanded ---
+
+  /**
+   *
+   * This is the "expanded" version of the `createdAt` type. It is identical except for the fact
+   * that IDEs will display its contents (a union type) directly, rather than the name of this type.
+   * In some cases, this is a preferable DX, making the types easier to read for users.
+   *
+   */
+  export type createdAt$Expanded<
+    _$Scalars extends $$Utilities.Schema.Scalar.Registry =
+      $$Utilities.Schema.Scalar.Registry.Empty,
+  > = $$Utilities.Simplify<
+    $Select.Indicator.NoArgsIndicator | createdAt$SelectionSet<_$Scalars>
   >;
 }
 
@@ -7099,6 +7307,10 @@ export namespace $NamedTypes {
     _$Scalars extends $$Utilities.Schema.Scalar.Registry =
       $$Utilities.Schema.Scalar.Registry.Empty,
   > = AssetMetadata<_$Scalars>;
+  export type $AssetPricePoint<
+    _$Scalars extends $$Utilities.Schema.Scalar.Registry =
+      $$Utilities.Schema.Scalar.Registry.Empty,
+  > = AssetPricePoint<_$Scalars>;
   export type $Pnl<
     _$Scalars extends $$Utilities.Schema.Scalar.Registry =
       $$Utilities.Schema.Scalar.Registry.Empty,

--- a/web/src/hooks/useWSForDetail.tsx
+++ b/web/src/hooks/useWSForDetail.tsx
@@ -1,20 +1,25 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import {
   CampaignMessage,
   PriceMessage,
   PricePoint,
   PriceSnapshot,
+  RawPricePoint,
   SimpleCampaignDetail,
   SimpleMarketKey,
 } from "@/types";
 import config from "@/config";
 import { formatSimpleCampaignDetail } from "@/utils/format/formatCampaign";
 import getPeriodOfCampaign from "@/utils/getPeriodOfCampaign";
+import mergePricePoints from "@/utils/mergePricePoints";
 
 type Message = PriceMessage | CampaignMessage | PriceSnapshot;
+
+const PRICES_TABLE = "oracles_ninelives_prices_2";
+
 export function useWSForDetail({
   asset,
   starting,
@@ -29,6 +34,12 @@ export function useWSForDetail({
   simple: boolean;
 }) {
   const queryClient = useQueryClient();
+  // The campaign object is rewritten in the query cache on every trade;
+  // read it through a ref so those updates don't tear down the socket.
+  const previousDataRef = useRef(previousData);
+  previousDataRef.current = previousData;
+  const poolAddress = previousData.poolAddress;
+
   useEffect(() => {
     if (!queryClient) return;
 
@@ -37,6 +48,13 @@ export function useWSForDetail({
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let campaignTimer: ReturnType<typeof setTimeout> | null = null;
     let destroyed = false;
+
+    const base = asset.toUpperCase();
+    const toPoint = (i: RawPricePoint): PricePoint => ({
+      price: Number(i.amount.toFixed(config.simpleMarkets[asset].decimals)),
+      id: i.id,
+      timestamp: new Date(i.created_by).getTime(),
+    });
 
     const connect = () => {
       if (destroyed) return;
@@ -50,22 +68,22 @@ export function useWSForDetail({
           JSON.stringify({
             ask_for_snapshot: [
               {
-                table: "oracles_ninelives_prices_2",
+                table: PRICES_TABLE,
                 fields: [
                   {
                     name: "base",
-                    filter_constraints: { et: asset.toUpperCase() },
+                    filter_constraints: { et: base },
                   },
                 ],
               },
             ],
             add: [
               {
-                table: "oracles_ninelives_prices_2",
+                table: PRICES_TABLE,
                 fields: [
                   {
                     name: "base",
-                    filter_constraints: { et: asset.toUpperCase() },
+                    filter_constraints: { et: base },
                   },
                 ],
               },
@@ -75,7 +93,7 @@ export function useWSForDetail({
                 fields: [
                   {
                     name: "emitter_addr",
-                    filter_constraints: { et: previousData.poolAddress },
+                    filter_constraints: { et: poolAddress },
                   },
                 ],
               },
@@ -88,67 +106,50 @@ export function useWSForDetail({
         try {
           const msg: Message = JSON.parse(raw.data);
 
-          if (
-            msg.table === "" &&
-            msg.snapshot_toplevel &&
-            msg.snapshot_toplevel[0].table === "oracles_ninelives_prices_2"
-          ) {
+          if (msg.table === "") {
+            const prices = msg.snapshot_toplevel?.find(
+              (t) => t.table === PRICES_TABLE,
+            );
+            if (!prices) return;
+            const points = prices.snapshot
+              .filter((i) => {
+                if (String(i.base).toUpperCase() !== base) return false;
+                const ts = new Date(i.created_by).getTime();
+                return ts >= starting && ending >= ts;
+              })
+              .map(toPoint);
+            if (points.length === 0) return;
             queryClient.setQueryData<PricePoint[] | undefined>(
               ["assetPrices", asset, starting, ending],
-              () =>
-                msg
-                  .snapshot_toplevel![0].snapshot.filter((i) => {
-                    const ts = new Date(i.created_by).getTime();
-                    return ts >= starting && ending >= ts;
-                  })
-                  .map((i) => ({
-                    price: Number(
-                      i.amount.toFixed(config.simpleMarkets[asset].decimals),
-                    ),
-                    id: i.id,
-                    timestamp: new Date(i.created_by).getTime(),
-                  }))
-                  .sort((a, b) => a.timestamp - b.timestamp),
+              (previous) => mergePricePoints(previous, points),
             );
             return;
           }
 
-          if (msg.table === "oracles_ninelives_prices_2") {
-            const ts = new Date(msg.content.created_by).getTime();
+          if (msg.table === PRICES_TABLE) {
+            // The server only filters rows by base when its table
+            // filtering feature is enabled, so drop other assets here.
+            if (String(msg.content.base).toUpperCase() !== base) return;
 
+            const ts = new Date(msg.content.created_by).getTime();
             if (ts <= starting || ts > ending) return;
 
-            const newPoint: PricePoint = {
-              price: Number(
-                msg.content.amount.toFixed(
-                  config.simpleMarkets[asset].decimals,
-                ),
-              ),
-              id: msg.content.id,
-              timestamp: ts,
-            };
-
             queryClient.setQueryData<PricePoint[] | undefined>(
               ["assetPrices", asset, starting, ending],
-              (previousData) => {
-                if (!previousData) {
-                  return [newPoint];
-                }
-
-                return [...previousData, newPoint];
-              },
+              (previous) => mergePricePoints(previous, [toPoint(msg.content)]),
             );
             return;
           }
 
+          const campaignData = previousDataRef.current;
           if (
             msg.table === "ninelives_campaigns_1" &&
             simple &&
             msg.content.content.priceMetadata &&
             msg.content.content.priceMetadata.baseAsset.toLowerCase() ===
               asset &&
-            msg.content.id !== previousData.identifier &&
-            previousData.ending !== msg.content.content.ending * 1000
+            msg.content.id !== campaignData.identifier &&
+            campaignData.ending !== msg.content.content.ending * 1000
           ) {
             const content = msg.content.content;
             const identifier = msg.content.id as `0x${string}`;
@@ -157,7 +158,7 @@ export function useWSForDetail({
               ...content,
               identifier,
             });
-            const prevPeriod = getPeriodOfCampaign(previousData);
+            const prevPeriod = getPeriodOfCampaign(campaignData);
             const nextPeriod = getPeriodOfCampaign(nextData);
 
             if (nextPeriod !== prevPeriod) {
@@ -166,6 +167,7 @@ export function useWSForDetail({
 
             const timeleft = content.starting * 1000 - Date.now();
 
+            if (campaignTimer) clearTimeout(campaignTimer);
             campaignTimer = setTimeout(
               () =>
                 queryClient.setQueryData(
@@ -207,5 +209,5 @@ export function useWSForDetail({
 
       ws?.close();
     };
-  }, [asset, starting, ending, previousData, simple, queryClient]);
+  }, [asset, starting, ending, poolAddress, simple, queryClient]);
 }

--- a/web/src/hooks/useWSForTrades.tsx
+++ b/web/src/hooks/useWSForTrades.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import {
   CampaignDetail,
   SimpleCampaignDetail,
@@ -26,6 +26,12 @@ export function useWSForTrades({
 }) {
   const queryClient = useQueryClient();
   const account = useAppKitAccount();
+  // This handler rewrites the simpleCampaign cache entry on every
+  // trade, which feeds back into previousData; read it through a ref
+  // so those updates don't tear down and reconnect the socket.
+  const previousDataRef = useRef(previousData);
+  previousDataRef.current = previousData;
+  const poolAddress = previousData.poolAddress;
   useEffect(() => {
     if (!queryClient) return;
 
@@ -47,7 +53,7 @@ export function useWSForTrades({
                 fields: [
                   {
                     name: "emitter_addr",
-                    filter_constraints: { et: previousData.poolAddress },
+                    filter_constraints: { et: poolAddress },
                   },
                 ],
               },
@@ -61,6 +67,7 @@ export function useWSForTrades({
           const msg: Message = JSON.parse(raw.data);
 
           if (msg.table === "ninelives_buys_and_sells_1") {
+            const campaignData = previousDataRef.current;
             // Update Live Trades
             queryClient.setQueryData<Trade[]>(
               ["campaignTrades", msg.content.campaign_id],
@@ -109,9 +116,9 @@ export function useWSForTrades({
             );
 
             // Update Simple Campaign Detail
-            const period = getPeriodOfCampaign(previousData);
+            const period = getPeriodOfCampaign(campaignData);
             queryClient.setQueryData<SimpleCampaignDetail>(
-              ["simpleCampaign", previousData.priceMetadata.baseAsset, period],
+              ["simpleCampaign", campaignData.priceMetadata.baseAsset, period],
               (data) =>
                 ({
                   ...data,
@@ -137,8 +144,8 @@ export function useWSForTrades({
               queryClient.invalidateQueries({
                 queryKey: [
                   "positions",
-                  previousData.poolAddress,
-                  previousData.outcomes,
+                  campaignData.poolAddress,
+                  campaignData.outcomes,
                   account.address,
                   isDpm,
                 ],
@@ -146,7 +153,7 @@ export function useWSForTrades({
               queryClient.invalidateQueries({
                 queryKey: [
                   "dppmShareEstimation",
-                  previousData.poolAddress,
+                  campaignData.poolAddress,
                   account.address,
                   `0x${msg.content.outcome_id}`,
                   true,
@@ -155,7 +162,7 @@ export function useWSForTrades({
               queryClient.invalidateQueries({
                 queryKey: [
                   "dppmShareEstimation",
-                  previousData.poolAddress,
+                  campaignData.poolAddress,
                   account.address,
                   `0x${msg.content.outcome_id}`,
                   false,
@@ -171,8 +178,8 @@ export function useWSForTrades({
               queryClient.invalidateQueries({
                 queryKey: [
                   "prices",
-                  previousData.poolAddress,
-                  previousData.outcomes,
+                  campaignData.poolAddress,
+                  campaignData.outcomes,
                 ],
               });
             }
@@ -206,5 +213,5 @@ export function useWSForTrades({
 
       ws?.close();
     };
-  }, [previousData, simple, queryClient, account.address, isDpm]);
+  }, [poolAddress, queryClient, account.address, isDpm]);
 }

--- a/web/src/providers/graphqlClient.tsx
+++ b/web/src/providers/graphqlClient.tsx
@@ -610,6 +610,14 @@ export const requestPriceChanges = (poolAddress: string) =>
     shares: { shares: true, identifier: true },
   });
 
+export const requestAssetPrices = (base: string, from: number, until: number) =>
+  graph9Lives.query.assetPrices({
+    $: { base, from, until },
+    id: true,
+    amount: true,
+    createdAt: true,
+  });
+
 export const requestWeeklyVolume = (poolAddress: string) =>
   graph9Lives.query.campaignWeeklyVolume({ $: { poolAddress } });
 

--- a/web/src/utils/mergePricePoints.ts
+++ b/web/src/utils/mergePricePoints.ts
@@ -1,0 +1,22 @@
+import type { PricePoint } from "@/types";
+
+// CDC delivers price rows in commit order, not created_by order, and a
+// snapshot can arrive after live points have already been charted. Keep
+// the cache unique by row id and sorted by timestamp so the chart line
+// never doubles back on itself.
+export default function mergePricePoints(
+  previous: PricePoint[] | undefined,
+  incoming: PricePoint[],
+): PricePoint[] {
+  if (!previous || previous.length === 0) {
+    return [...incoming].sort((a, b) => a.timestamp - b.timestamp);
+  }
+  const last = previous[previous.length - 1];
+  if (incoming.length === 1 && incoming[0].timestamp > last.timestamp) {
+    return [...previous, incoming[0]];
+  }
+  const byId = new Map<number, PricePoint>();
+  for (const p of previous) byId.set(p.id, p);
+  for (const p of incoming) byId.set(p.id, p);
+  return Array.from(byId.values()).sort((a, b) => a.timestamp - b.timestamp);
+}


### PR DESCRIPTION
## What this fixes

The short-term market price chart took a long time to load and drew garbled artifacts on live updates (screenshot-verified against production data on a local run).

### Frontend
- **Reconnect storm**: `useWSForDetail`/`useWSForTrades` listed the campaign object in their effect deps, and `useWSForTrades` rewrites that object on every trade — so every trade from anyone tore down and reopened both websockets and re-requested a snapshot. Sockets are now stable per campaign (object read through a ref).
- **The "scribble"**: live points were appended blindly, but CDC delivers rows in commit order, not `created_by` order. New `mergePricePoints` util keeps the cache sorted by timestamp and unique by row id. Chart components also sort as a render safety net.
- **The "wiggle"**: the recharts `Line` never disabled the default 1.5s path-morph animation (the `Area` did) — with ~1s ticks the line was permanently mid-morph. Animation off, `monotone` smoothing → `linear`.
- **No cross-asset bleed**: price messages are now checked against the chart's `base` client-side (the server only filters behind `FeatureFilterTables`).
- The plot is memoized and the volume label moved out, so trade updates no longer re-render it.
- Charts seed over HTTP via the new `assetPrices` query and stay live via the websocket; if the query isn't deployed yet the chart degrades to websocket-only exactly as before.

### Backend
- New `assetPrices(base, from, until)` GraphQL query: most recent ≤5000 price rows in a window, oldest first (gqlgen + graffle regenerated).
- `websocket.database`: ring-buffer snapshots now come out in chronological order (wrapped buffers previously emitted newest-chunk-first), and the prices buffer is **backfilled from the database at startup** — restarts no longer wipe chart history. Backfill verified against a real Postgres 14 (per-asset cap, ordering, both `float8` and `numeric` amount columns). Note per Alex: this is the stopgap that papers over the restart symptom — the underlying degradation/restart cause is being investigated separately.

### Tests
- `cmd/websocket.database`: ring-buffer ordering unit tests + DB-gated backfill integration test (`SPN_TEST_TIMESCALE_URL`).
- `web`: `mergePricePoints` unit tests.

Go build/vet/tests pass; web typecheck/lint/prettier clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
