### PR TITLE
Reap dead websocket connections; stop snapshot and fan-out overload

### DIFF
--- a/cmd/websocket.database/main.go
+++ b/cmd/websocket.database/main.go
@@ -65,9 +65,13 @@ type partitionedBuffer struct {
 
 // dumpRequest wraps the snapshot reply channel with a context so the
 // buffer goroutine can abandon the send when the requester is gone.
+// filters carries the requester's snapshot constraints so the buffer
+// goroutine only copies the tables (and, for the prices table, the
+// single partition) actually asked for.
 type dumpRequest struct {
-	ctx   context.Context
-	reply chan []TableContent
+	ctx     context.Context
+	reply   chan []TableContent
+	filters map[string]map[string]*FilterConstraint
 }
 
 func newPartitionedBuffer() *partitionedBuffer {
@@ -310,8 +314,27 @@ func main() {
 				if !ok {
 					return
 				}
-				content := make([]TableContent, 0, len(buffer))
+				// Only copy what the requester asked for: dumps
+				// are per connection, and copying every partition
+				// of every table for each request made reconnect
+				// storms expensive.
+				content := make([]TableContent, 0, len(req.filters))
 				for k, pb := range buffer {
+					tableFilter, requested := req.filters[k]
+					if !requested {
+						continue
+					}
+					if k == PricesTable {
+						if c := tableFilter[PricesPartitionKey]; c != nil {
+							if rb := pb.buffers[fmt.Sprintf("%v", c.Et)]; rb != nil {
+								content = append(content, TableContent{
+									Table:    k,
+									Snapshot: rb.itemsInOrder(),
+								})
+							}
+							continue
+						}
+					}
 					content = append(content, TableContent{
 						Table:    k,
 						Snapshot: pb.allItems(),
@@ -476,7 +499,7 @@ func main() {
 							// Send the dump request, giving up if the
 							// connection or process is shutting down.
 							select {
-							case dumpChan <- dumpRequest{ctx: connCtx, reply: replyChan}:
+							case dumpChan <- dumpRequest{ctx: connCtx, reply: replyChan, filters: snapshotFilters}:
 							case <-connCtx.Done():
 								return
 							case <-masterCtx.Done():

--- a/lib/websocket/broadcast.go
+++ b/lib/websocket/broadcast.go
@@ -20,7 +20,9 @@ type (
 
 func NewBroadcast[A any]() *Broadcast[A] {
 	var (
-		broadcastRequests      = make(chan A)
+		// Buffered so publishers (the CDC ack path) don't stall
+		// while the broadcast goroutine fans out to subscribers.
+		broadcastRequests      = make(chan A, 1024)
 		subscriptionRequests   = make(chan registration[A])
 		unsubscriptionRequests = make(chan uint64)
 		shutdownRequests       = make(chan bool)

--- a/lib/websocket/control_test.go
+++ b/lib/websocket/control_test.go
@@ -1,0 +1,45 @@
+package websocket
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Control run: with keepalives effectively disabled (the pre-fix
+// behavior), silent zombies must persist, proving the reaping test
+// detects the leak rather than passing vacuously.
+func TestControlZombiesPersistWithoutKeepalive(t *testing.T) {
+	oldWrite, oldPong, oldPing := WriteWait, PongWait, PingPeriod
+	WriteWait, PongWait, PingPeriod = time.Hour, time.Hour, time.Hour
+	defer func() { WriteWait, PongWait, PingPeriod = oldWrite, oldPong, oldPing }()
+
+	Endpoint("/controltest", func(ctx context.Context, ip string, q url.Values, replies <-chan []byte, outgoing chan<- []byte, shutdown chan<- error, requestShutdown <-chan bool) {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-requestShutdown:
+				return
+			case <-replies:
+			}
+		}
+	})
+	server := httptest.NewServer(http.DefaultServeMux)
+	defer server.Close()
+	addr := strings.TrimPrefix(server.URL, "http://")
+
+	baseline := endpointGoroutines()
+
+	conn := zombieHandshake(t, addr, "/controltest")
+	defer conn.Close()
+
+	time.Sleep(3 * time.Second)
+	if got := endpointGoroutines(); got <= baseline {
+		t.Fatalf("expected zombie goroutines to persist without keepalive, baseline %d, got %d", baseline, got)
+	}
+}

--- a/lib/websocket/websocket.go
+++ b/lib/websocket/websocket.go
@@ -12,6 +12,26 @@ import (
 
 const DeadlinePong = 3 * time.Minute
 
+// Keepalive tuning. Without read deadlines and server pings, a client
+// that vanishes without closing TCP (mobile network drop, NAT reset,
+// laptop sleep) leaves its reader goroutine blocked in ReadMessage
+// forever, and without a write deadline a client that stops reading
+// blocks the writer forever once the socket buffer fills. The
+// connection is hijacked, so the request context never fires either:
+// the goroutines, buffers, and broadcast subscription of every such
+// connection leak for the life of the process. Vars rather than
+// consts so tests can shrink them.
+var (
+	// WriteWait is the deadline applied to any single write.
+	WriteWait = 10 * time.Second
+	// PongWait is how long we go without hearing anything from
+	// the client before considering the connection dead.
+	PongWait = 60 * time.Second
+	// PingPeriod is how often the writer pings the client. Must
+	// be comfortably less than PongWait.
+	PingPeriod = 25 * time.Second
+)
+
 var websocketUpgrader = websocket.Upgrader{
 	ReadBufferSize:  4096,
 	WriteBufferSize: 4096,
@@ -38,6 +58,14 @@ func Endpoint(endpoint string, handler func(ctx context.Context, ipAddr string, 
 
 		ipAddress := r.RemoteAddr
 
+		// Any inbound traffic (pongs included) proves the client
+		// is alive; a quiet PongWait means it's gone and the
+		// reader should error out so the connection tears down.
+		websocketConn.SetReadDeadline(time.Now().Add(PongWait))
+		websocketConn.SetPongHandler(func(string) error {
+			return websocketConn.SetReadDeadline(time.Now().Add(PongWait))
+		})
+
 		// connCtx is cancelled when any part of this connection tears down.
 		// All spawned goroutines should select on connCtx.Done().
 		connCtx, connCancel := context.WithCancel(r.Context())
@@ -60,7 +88,7 @@ func Endpoint(endpoint string, handler func(ctx context.Context, ipAddr string, 
 			for {
 				msgType, content, err := websocketConn.ReadMessage()
 				if err != nil {
-					slog.Error("failed to read websocket message",
+					slog.Debug("failed to read websocket message",
 						"ip", ipAddress,
 						"err", err,
 					)
@@ -70,6 +98,7 @@ func Endpoint(endpoint string, handler func(ctx context.Context, ipAddr string, 
 					}
 					return
 				}
+				websocketConn.SetReadDeadline(time.Now().Add(PongWait))
 				switch msgType {
 				case websocket.PongMessage:
 					continue
@@ -109,6 +138,8 @@ func Endpoint(endpoint string, handler func(ctx context.Context, ipAddr string, 
 		// Writer goroutine
 		go func() {
 			defer connCancel() // ensure everything tears down when writer exits
+			pingTicker := time.NewTicker(PingPeriod)
+			defer pingTicker.Stop()
 			for {
 				select {
 				case <-connCtx.Done():
@@ -116,6 +147,15 @@ func Endpoint(endpoint string, handler func(ctx context.Context, ipAddr string, 
 						"ip", ipAddress,
 					)
 					return
+				case <-pingTicker.C:
+					deadline := time.Now().Add(WriteWait)
+					if err := websocketConn.WriteControl(websocket.PingMessage, nil, deadline); err != nil {
+						slog.Debug("failed to ping client",
+							"ip", ipAddress,
+							"err", err,
+						)
+						return
+					}
 				case <-chanPongs:
 					deadline := time.Now().Add(DeadlinePong)
 					if err := websocketConn.WriteControl(websocket.PongMessage, nil, deadline); err != nil {
@@ -129,8 +169,9 @@ func Endpoint(endpoint string, handler func(ctx context.Context, ipAddr string, 
 					if !ok {
 						return
 					}
+					websocketConn.SetWriteDeadline(time.Now().Add(WriteWait))
 					if err := websocketConn.WriteMessage(websocket.TextMessage, message); err != nil {
-						slog.Error("failed to write websocket message",
+						slog.Debug("failed to write websocket message",
 							"ip", ipAddress,
 							"err", err,
 						)

--- a/lib/websocket/websocket_test.go
+++ b/lib/websocket/websocket_test.go
@@ -1,0 +1,158 @@
+package websocket
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	gws "github.com/gorilla/websocket"
+)
+
+// endpointGoroutines counts goroutines with a frame in this package's
+// connection machinery (reader, writer, or the upgraded handler).
+func endpointGoroutines() int {
+	buf := make([]byte, 1<<22)
+	n := runtime.Stack(buf, true)
+	count := 0
+	for _, block := range strings.Split(string(buf[:n]), "\n\n") {
+		if strings.Contains(block, "lib/websocket/websocket.go") {
+			count++
+		}
+	}
+	return count
+}
+
+// zombieHandshake performs a bare websocket upgrade over raw TCP and
+// then goes silent: it never reads, writes, or pongs again, exactly
+// like a client whose network vanished without closing TCP.
+func zombieHandshake(t *testing.T, addr, path string) net.Conn {
+	t.Helper()
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	key := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x42}, 16))
+	fmt.Fprintf(conn, "GET %s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: %s\r\nSec-WebSocket-Version: 13\r\n\r\n", path, addr, key)
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read upgrade response: %v", err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("upgrade failed: %v", resp.Status)
+	}
+	return conn
+}
+
+// TestDeadConnectionsAreReaped proves that connections whose clients
+// go silent are torn down: flooded connections via the write deadline
+// (nobody draining the socket), quiet ones via the ping/pong read
+// deadline. A client that answers pings survives. Without deadlines
+// and pings the zombies' goroutines block forever and the goroutine
+// count never returns to baseline.
+func TestDeadConnectionsAreReaped(t *testing.T) {
+	// Shrink keepalive windows so the test runs in seconds.
+	oldWrite, oldPong, oldPing := WriteWait, PongWait, PingPeriod
+	WriteWait, PongWait, PingPeriod = 500*time.Millisecond, 1500*time.Millisecond, 300*time.Millisecond
+	defer func() { WriteWait, PongWait, PingPeriod = oldWrite, oldPong, oldPing }()
+
+	// A handler shaped like the production one: pushes payloads at
+	// the client and drains replies until the connection dies.
+	payload := bytes.Repeat([]byte("x"), 32*1024)
+	Endpoint("/reaptest-flood", func(ctx context.Context, ip string, q url.Values, replies <-chan []byte, outgoing chan<- []byte, shutdown chan<- error, requestShutdown <-chan bool) {
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-requestShutdown:
+				return
+			case <-replies:
+			case <-ticker.C:
+				select {
+				case outgoing <- payload:
+				default:
+				}
+			}
+		}
+	})
+	// A quiet endpoint that never writes, so only the ping/pong
+	// read deadline can detect a dead client.
+	Endpoint("/reaptest-quiet", func(ctx context.Context, ip string, q url.Values, replies <-chan []byte, outgoing chan<- []byte, shutdown chan<- error, requestShutdown <-chan bool) {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-requestShutdown:
+				return
+			case <-replies:
+			}
+		}
+	})
+	server := httptest.NewServer(http.DefaultServeMux)
+	defer server.Close()
+	addr := strings.TrimPrefix(server.URL, "http://")
+
+	baseline := endpointGoroutines()
+
+	// A healthy client: reads continuously, so gorilla's default
+	// ping handler answers the server's pings for it.
+	healthy, _, err := gws.DefaultDialer.Dial("ws://"+addr+"/reaptest-flood", nil)
+	if err != nil {
+		t.Fatalf("healthy dial: %v", err)
+	}
+	defer healthy.Close()
+	healthyDead := make(chan struct{})
+	go func() {
+		defer close(healthyDead)
+		for {
+			if _, _, err := healthy.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Zombies: upgraded, then silent forever.
+	for i := 0; i < 2; i++ {
+		conn := zombieHandshake(t, addr, "/reaptest-flood")
+		defer conn.Close()
+	}
+	quietZombie := zombieHandshake(t, addr, "/reaptest-quiet")
+	defer quietZombie.Close()
+
+	// Shortly after connecting, the healthy client and at least the
+	// quiet zombie (which cannot be reaped before PongWait) must be
+	// holding endpoint goroutines.
+	time.Sleep(300 * time.Millisecond)
+	if got := endpointGoroutines(); got < baseline+6 {
+		t.Fatalf("expected at least %d endpoint goroutines while connections are live, got %d", baseline+6, got)
+	}
+
+	// Within a few PongWaits every zombie must be gone, leaving only
+	// the healthy connection's goroutines.
+	target := baseline + 3 // healthy reader + writer + handler
+	deadline := time.Now().Add(6 * PongWait)
+	for endpointGoroutines() > target && time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+	}
+	if got := endpointGoroutines(); got > target {
+		t.Fatalf("zombie connections were not reaped: %d endpoint goroutines still running (baseline %d, target %d)", got, baseline, target)
+	}
+
+	// The healthy client must have survived the reaping.
+	select {
+	case <-healthyDead:
+		t.Fatal("healthy client was disconnected by the keepalive logic")
+	default:
+	}
+}


### PR DESCRIPTION
> Stacked on #84.

## The leak (measured on the deployed service)

`websocket.9lives.so` exposes `/debug/pprof` publicly (worth locking down separately, see below). Monitoring it today shows the service is **crash-looping roughly every 7 minutes**: `TotalAlloc` resets observed at ~15:11, ~15:19, ~15:26 (CEST), with heap racing from ~45MB to 100+MB within minutes of each boot and `MaxRSS` peaking ~125MB right before each death — consistent with an OOM kill at a ~128MB limit. Every restart wipes the in-memory snapshot ring buffer, which is why charts keep losing their history.

## Root cause

`lib/websocket` sets **no read deadline, no write deadline, and never pings**:

- A client that vanishes without closing TCP (mobile drop, NAT reset, laptop sleep) leaves its reader goroutine blocked in `ReadMessage` forever.
- A client that stops reading blocks the writer in `WriteMessage` forever once the socket buffer fills.
- The connection is hijacked, so `r.Context()` never fires — teardown depends entirely on read/write errors that never come.

Each zombie permanently pins 3 goroutines, its channel buffers (up to 1000 queued encoded messages), and its broadcast subscription — and the broadcast goroutine attempts a send to **every** subscriber for **every** DB insert, so zombies also tax all broadcasts (and the CDC ack path blocked on that unbuffered fan-out). On top of that, every snapshot request copied **every partition of every table** before filtering; combined with the frontend reconnect storm (fixed in #84 — both sockets reconnected on every trade), that's the allocation treadmill driving the OOM.

## Fix

- Read deadline refreshed by pongs/inbound frames + ping ticker in the writer + write deadline on every write → dead connections error out within `PongWait` (60s) and tear down completely (unsubscribe included).
- Buffered broadcast intake so the CDC ack path doesn't stall on fan-out.
- Snapshot dumps only copy the requested tables, and for the prices table only the requested asset's partition (one ring instead of all assets).

## Proof

`lib/websocket` tests:
- `TestDeadConnectionsAreReaped` — raw-TCP zombies (upgrade, then silence) are reaped via both paths: write-deadline on a flooding endpoint, read-deadline on a quiet endpoint; a ping-answering client survives.
- `TestControlZombiesPersistWithoutKeepalive` — with keepalives disabled (pre-fix behavior), zombies persist; i.e. the reaping test fails on the old code rather than passing vacuously.

Expected effect in prod: #84 removes the reconnect storm; this PR bounds zombie lifetime and cuts per-snapshot work by ~Nx (N = number of assets). Together they should stop the OOM loop — and with it the recurring history wipes.

## Follow-ups worth considering (not in this PR)
- `/debug/pprof` is publicly reachable on the websocket host (registered on `DefaultServeMux`, which `ListenAndServe` serves); should move to an internal-only listener.
- `setup.Exitf("ack: ...")` kills the whole process on any transient CDC ack error — possibly a second restart trigger worth softening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
