### PR TITLE
Re-land: liveline market chart against main

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -44,6 +44,7 @@
     "graffle": "8.0.0-next.140",
     "graphql": "^16.12.0",
     "keccak": "^3.0.4",
+    "liveline": "0.0.7",
     "next": "16.1.6",
     "posthog-js": "^1.302.2",
     "react": "19.2.3",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       keccak:
         specifier: ^3.0.4
         version: 3.0.4
+      liveline:
+        specifier: 0.0.7
+        version: 0.0.7(react@19.2.3)
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -4284,6 +4287,12 @@ packages:
 
   lit@3.3.0:
     resolution: {integrity: sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==}
+
+  liveline@0.0.7:
+    resolution: {integrity: sha512-S1Weo1kmefiOCNaW/WFXErqJXlV8A/ldIkIthaOeT57I2ZhqhKLKQDJ1wfabtMSK9vJeU8PeMNHd8Sr8TLByWQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=18'
 
   loader-runner@4.3.1:
     resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
@@ -11217,6 +11226,10 @@ snapshots:
       '@lit/reactive-element': 2.1.2
       lit-element: 4.2.2
       lit-html: 3.3.2
+
+  liveline@0.0.7(react@19.2.3):
+    dependencies:
+      react: 19.2.3
 
   loader-runner@4.3.1: {}
 

--- a/web/src/components/v2/chart.tsx
+++ b/web/src/components/v2/chart.tsx
@@ -1,24 +1,14 @@
 "use client";
 import config from "@/config";
 import { PricePoint, SimpleMarketKey } from "@/types";
-import {
-  ComposedChart,
-  ResponsiveContainer,
-  Line,
-  Area,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ReferenceLine,
-  ReferenceDot,
-} from "recharts";
+import { memo, useMemo } from "react";
+import { Liveline } from "liveline";
 
-export default function AssetPriceChart({
+function AssetPriceChart({
   symbol,
   basePrice,
   starting,
   ending,
-  volume,
   assetPrices,
 }: {
   id: string;
@@ -26,283 +16,54 @@ export default function AssetPriceChart({
   basePrice: number;
   starting: number;
   ending: number;
-  volume: string;
   assetPrices: PricePoint[];
 }) {
   const chartHeight = 300;
-  if (assetPrices.length < 1) {
-    return <div className="skeleton w-full" style={{ height: chartHeight }} />;
-  }
-  const latestPoint = assetPrices[assetPrices.length - 1];
-  const latestPrice = latestPoint.price;
-  const latestTimestamp = latestPoint.timestamp;
+  const decimals = config.simpleMarkets[symbol].decimals;
+  // Rows arrive in database commit order, which is not always
+  // created_by order, so sort before drawing.
+  const data = useMemo(
+    () =>
+      [...assetPrices]
+        .sort((a, b) => a.timestamp - b.timestamp)
+        .map((p) => ({
+          time: p.timestamp / 1000,
+          value: p.price,
+        })),
+    [assetPrices],
+  );
+  const latestPrice = data.length > 0 ? data[data.length - 1].value : basePrice;
   const priceIsAbove = latestPrice > basePrice;
-  const timeDiff = ending - starting;
-  const MIN = 1000 * 60;
-  const HOUR = MIN * 60;
-  const DAY = HOUR * 24;
-  const MONTH = DAY * 30;
-  const YEAR = MONTH * 12;
-  const prices = assetPrices.map((i) => i.price);
-  const minPrice = Math.min(...prices, basePrice);
-  const maxPrice = Math.max(...prices, basePrice);
-  const simpleDiff = Math.max(
-    Math.abs(basePrice - minPrice),
-    Math.abs(basePrice - maxPrice),
-  );
-  const minY = basePrice - simpleDiff;
-  const maxY = basePrice + simpleDiff;
-  const isDailyMarket = DAY >= timeDiff && timeDiff > HOUR;
-  const formatFn = (ts: number) => {
-    const date = new Date(ts);
-    switch (true) {
-      case timeDiff > MONTH:
-        return date.toLocaleString("default", {
-          month: "short",
-          year: timeDiff > YEAR ? "2-digit" : undefined,
-        });
-      case MONTH >= timeDiff && timeDiff > DAY:
-        return date.toLocaleString("default", {
-          day: "numeric",
-          month: "short",
-        });
-      case isDailyMarket:
-        return date.toLocaleString("default", {
-          day: "numeric",
-          month: "short",
-        });
-      default:
-        return date.toLocaleString("default", {
-          hour: "numeric",
-          minute: "2-digit",
-        });
-    }
-  };
-  const pointsData = [
-    { id: 1, timestamp: starting, price: basePrice },
-    ...assetPrices,
-  ];
-  const uniquePoints = Array.from(
-    new Map(pointsData.map((p) => [p.timestamp, p])).values(),
-  );
-
-  const PulseDot = ({ cx, cy }: { cx: number; cy: number }) => {
-    return (
-      <circle
-        cx={cx}
-        r="10"
-        cy={cy}
-        fill={priceIsAbove ? "#DCFCE7" : "#fecaca"}
-      >
-        <animate
-          attributeName="r"
-          from="8"
-          to="20"
-          dur="1.5s"
-          begin="0s"
-          repeatCount="indefinite"
-        />
-      </circle>
-    );
-  };
-
-  const Dot = ({ cx, cy }: { cx: number; cy: number }) => {
-    return (
-      <circle
-        cx={cx}
-        r="4"
-        cy={cy}
-        stroke="#fff"
-        strokeWidth={2}
-        fill={priceIsAbove ? "#16A34A" : "#DC2828"}
-      />
-    );
-  };
-
-  const PriceInd = ({ cx, cy }: { cx: number; cy: number }) => (
-    <g transform="translate(0,-32)">
-      <rect
-        x={cx - 45}
-        y={cy - 10}
-        width={90}
-        height={20}
-        fill={priceIsAbove ? "#16A34A" : "#DC2828"}
-        rx={8}
-        stroke={priceIsAbove ? "#16A34A" : "#DC2828"}
-        strokeWidth={1}
-      />
-      <rect
-        x={cx - 41}
-        y={cy - 3.5}
-        width={6}
-        height={6}
-        fill={priceIsAbove ? "#16A34A" : "#DC2828"}
-        stroke="#FFF"
-        strokeWidth={1}
-        rx={3}
-      />
-      <text
-        x={cx}
-        y={cy + 4}
-        textAnchor="middle"
-        fontSize="12"
-        fontWeight="bold"
-        fill={"#FFF"}
-      >
-        ${latestPrice.toFixed(config.simpleMarkets[symbol].decimals)}
-      </text>
-    </g>
-  );
+  // Trailing window sized to the campaign, so every point stays in
+  // view for the market's whole lifetime.
+  const windowSecs = Math.max(60, Math.round((ending - starting) / 1000));
 
   return (
-    <ResponsiveContainer width="100%" height={chartHeight}>
-      <ComposedChart
-        data={uniquePoints}
-        margin={{
-          top: 43,
-          right: -60,
-          bottom: -18,
-          left: 0,
+    <div style={{ height: chartHeight }}>
+      <Liveline
+        data={data}
+        value={latestPrice}
+        loading={data.length === 0}
+        theme="light"
+        color={priceIsAbove ? "#16A34A" : "#DC2828"}
+        referenceLine={{
+          value: basePrice,
+          label: `BASE $${basePrice.toFixed(decimals)}`,
         }}
-      >
-        <ReferenceDot x={latestTimestamp} y={latestPrice} shape={Dot} />
-        <ReferenceDot
-          zIndex={0}
-          x={latestTimestamp}
-          y={latestPrice}
-          shape={PulseDot}
-        />
-        <Area
-          type="monotone"
-          dataKey="price"
-          stroke="none"
-          fill={priceIsAbove ? "#16A34A" : "#DC2828"}
-          fillOpacity={0.15}
-          isAnimationActive={false}
-          tooltipType="none"
-        />
-        <Line
-          dot={false}
-          dataKey={"price"}
-          zIndex={99}
-          type="monotone"
-          stroke={priceIsAbove ? "#16A34A" : "#DC2828"}
-          strokeWidth={2}
-          name={symbol.toUpperCase()}
-        />
-        <ReferenceLine
-          x={starting}
-          strokeWidth={2}
-          stroke="#D4D4D4"
-          strokeDasharray="5 5"
-          zIndex={100}
-          label={{
-            orientation: "bottom",
-            value: new Date(starting).toLocaleString("default", {
-              day: isDailyMarket ? "numeric" : undefined,
-              month: isDailyMarket ? "short" : undefined,
-              hour: isDailyMarket ? undefined : "numeric",
-              minute: isDailyMarket ? undefined : "2-digit",
-            }),
-            fontSize: 12,
-            fontWeight: "500",
-            fill: "#A3A3A3",
-            position: "insideBottomLeft",
-            dx: 0,
-            dy: 16,
-          }}
-        />
-        <ReferenceLine
-          y={basePrice}
-          zIndex={0}
-          label={{
-            value: `$${basePrice}`,
-            position: "centerBottom",
-            fill: "#525252",
-            dy: 10,
-            fontSize: 12,
-            fontWeight: "bold",
-          }}
-        />
-        <ReferenceLine
-          y={basePrice}
-          stroke="#E5E5E5"
-          strokeWidth={2}
-          zIndex={0}
-          label={{
-            value: "BASE",
-            position: "centerBottom",
-            fill: "#A3A3A3",
-            dy: -10,
-            fontSize: 12,
-            fontWeight: "bold",
-          }}
-        />
-        <YAxis
-          tick={{
-            fontSize: 12,
-            fill: "#0C0C0C",
-          }}
-          domain={[minY, maxY]}
-          dataKey="price"
-          axisLine={{
-            stroke: "#D4D4D4",
-            strokeWidth: 2,
-            strokeDasharray: "5 5",
-          }}
-          orientation="right"
-          tickFormatter={(value) => `$${value}`}
-          ticks={[]}
-        />
-        <XAxis
-          tick={{
-            fontSize: 12,
-            fill: "#A3A3A3",
-            transform: "translate(-6,-6)",
-            fontWeight: "500",
-          }}
-          type="number"
-          scale="time"
-          axisLine={false}
-          tickLine={false}
-          dataKey="timestamp"
-          domain={[starting, ending]}
-          ticks={[starting, ending]}
-          tickFormatter={formatFn}
-        />
-        <ReferenceDot x={latestTimestamp} y={latestPrice} shape={PriceInd} />
-        <Tooltip
-          labelFormatter={(ts) => {
-            const date = new Date(ts);
-            return date.toLocaleString("default", {
-              day: "numeric",
-              month: "short",
-              hour: "2-digit",
-              minute: "2-digit",
-              second: "2-digit",
-            });
-          }}
-          formatter={(c) => `$${c}`}
-          contentStyle={{
-            padding: 4,
-            borderRadius: 8,
-            backgroundColor: "rgba(24, 24, 24, 0.36)",
-            backdropFilter: "blur(2px)",
-          }}
-          labelStyle={{ fontSize: 10, color: "#F5F5F5", fontWeight: "500" }}
-          itemStyle={{
-            fontSize: 12,
-            marginTop: 4,
-            padding: "2px 4px",
-            fontWeight: "bold",
-            backgroundColor: "#F5F5F5",
-            borderRadius: 12,
-          }}
-        />
-      </ComposedChart>
-      <span className="absolute inset-x-0 -bottom-1 block text-center text-xs text-neutral-400">
-        ${volume} Vol.
-      </span>
-    </ResponsiveContainer>
+        window={windowSecs}
+        grid={false}
+        formatValue={(v) => `$${v.toFixed(decimals)}`}
+        formatTime={(t) =>
+          new Date(t * 1000).toLocaleString("default", {
+            hour: "numeric",
+            minute: "2-digit",
+          })
+        }
+      />
+    </div>
   );
 }
+
+// Only re-render the plot when its own inputs change; trades update the
+// surrounding campaign object every few seconds and must not touch it.
+export default memo(AssetPriceChart);

--- a/web/src/components/v2/chartWrapper.tsx
+++ b/web/src/components/v2/chartWrapper.tsx
@@ -29,7 +29,7 @@ export default function PriceChartWrapper({
     simple,
     isDpm: !!campaignData.isDpm,
   });
-  const { data: assetPrices, isLoading } = useQuery<PricePoint[]>({
+  const { data: assetPrices } = useQuery<PricePoint[]>({
     queryKey: ["assetPrices", symbol, starting, ending],
     queryFn: async () => {
       throw new Error(
@@ -43,21 +43,20 @@ export default function PriceChartWrapper({
     : "0";
   const formattedVolume = formatFusdc(totalVolume, 2);
 
-  if (!assetPrices || 1 > assetPrices.length || isLoading)
-    return <div className="skeleton" style={{ height: 320 }} />;
-
   return (
     <div className="relative">
       <AssetPriceChartMask simple={simple} campaignData={campaignData} />
       <AssetPriceChart
-        volume={formattedVolume}
         starting={starting}
         ending={ending}
         symbol={symbol}
-        assetPrices={assetPrices}
+        assetPrices={assetPrices ?? []}
         basePrice={+campaignData.priceMetadata.priceTargetForUp}
         id={campaignData.identifier}
       />
+      <span className="absolute inset-x-0 -bottom-1 block text-center text-xs text-neutral-400">
+        ${formattedVolume} Vol.
+      </span>
       <div className="absolute bottom-4 left-px z-[9] md:left-[-51px]">
         <LiveTrades campaignId={campaignData.identifier} />
       </div>


### PR DESCRIPTION
## Why a re-land

#87 (liveline) was merged, but its base was the branch of #84 — which was closed unmerged and auto-deleted. So **main never received the liveline chart**. This PR is the same chart swap directly against main.

Per Alex: this contains **only the liveline change** — none of the code from the other branches. No websocket adjustments of any kind (no hook rewrites, no service changes, no new queries, no backfill). The data flow is exactly what main has today; the chart sorts points by timestamp internally before drawing since it can't rely on arrival order.

## Scope (4 files)

- `web/src/components/v2/chart.tsx` — recharts plot → [liveline](https://github.com/benjitaylor/liveline) (MIT, canvas, 60fps, pinned 0.0.7): value badge tracking the tip, pulsing live dot, gradient fill, BASE reference line, crosshair scrub, and a loading line that morphs into the chart when data lands (replaces the gray skeleton).
- `web/src/components/v2/chartWrapper.tsx` — drop the skeleton gate (liveline owns the loading state), move the volume label out of the plot.
- `web/package.json` + lockfile — the dependency.

Verified on localhost against production data: renders live BTC ticks cleanly, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
