### PR TITLE
Make the websocket writer and heartbeat drains unconditional

### DIFF
--- a/lib/heartbeat/heartbeat.go
+++ b/lib/heartbeat/heartbeat.go
@@ -8,12 +8,19 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 )
 
 // EnvHeartbeatUrl to optionally send a GET to on request.
 const EnvHeartbeatUrl = "SPN_HEARTBEAT_URL"
 
 var urls = make(chan string)
+
+// client bounds the heartbeat request. The default client has no
+// timeout, so a hung request wedges the caller's pulse loop forever:
+// pulses stop even though the process is healthy, and anything
+// watching the heartbeat kills it for no reason.
+var client = &http.Client{Timeout: 10 * time.Second}
 
 func Pulse() {
 	u := <-urls
@@ -22,7 +29,7 @@ func Pulse() {
 		return
 	}
 	slog.Debug("sending a heartbeat message")
-	resp, err := http.Get(u)
+	resp, err := client.Get(u)
 	if err != nil {
 		slog.Error("error reporting to heartbeat", "err", err)
 		return

--- a/lib/websocket/websocket.go
+++ b/lib/websocket/websocket.go
@@ -12,6 +12,20 @@ import (
 
 const DeadlinePong = 3 * time.Minute
 
+// WriteWait bounds every write to the client. Without it, the writer
+// goroutine is the one place a channel stops draining: WriteMessage
+// on a client that stopped reading (or whose network vanished with
+// the TCP connection still open) blocks forever once the socket
+// buffer fills, so the messages channel backs up with encoded rows,
+// its connection never tears down, and the process accumulates these
+// wedged connections until it has to be killed. With a deadline the
+// write errors instead, the writer exits, and the whole connection
+// (goroutines, buffers, broadcast subscription) is torn down. Since
+// this service pushes rows to every subscriber continuously, a write
+// deadline alone is enough to reap dead subscribers within seconds.
+// A var, not a const, so tests can shrink it.
+var WriteWait = 30 * time.Second
+
 var websocketUpgrader = websocket.Upgrader{
 	ReadBufferSize:  4096,
 	WriteBufferSize: 4096,
@@ -129,6 +143,7 @@ func Endpoint(endpoint string, handler func(ctx context.Context, ipAddr string, 
 					if !ok {
 						return
 					}
+					websocketConn.SetWriteDeadline(time.Now().Add(WriteWait))
 					if err := websocketConn.WriteMessage(websocket.TextMessage, message); err != nil {
 						slog.Error("failed to write websocket message",
 							"ip", ipAddress,

--- a/lib/websocket/websocket_test.go
+++ b/lib/websocket/websocket_test.go
@@ -1,0 +1,139 @@
+package websocket
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// endpointGoroutines counts goroutines with a frame in this package's
+// connection machinery (reader, writer, or the upgraded handler).
+func endpointGoroutines() int {
+	buf := make([]byte, 1<<22)
+	n := runtime.Stack(buf, true)
+	count := 0
+	for _, block := range strings.Split(string(buf[:n]), "\n\n") {
+		if strings.Contains(block, "lib/websocket/websocket.go") {
+			count++
+		}
+	}
+	return count
+}
+
+// stalledClient performs a bare websocket upgrade over raw TCP and
+// then never reads again, like a client whose network vanished with
+// the TCP connection still open: the server's writes pile up until
+// the socket buffer is full.
+func stalledClient(t *testing.T, addr, path string) net.Conn {
+	t.Helper()
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	key := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x42}, 16))
+	fmt.Fprintf(conn, "GET %s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: %s\r\nSec-WebSocket-Version: 13\r\n\r\n", path, addr, key)
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read upgrade response: %v", err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("upgrade failed: %v", resp.Status)
+	}
+	return conn
+}
+
+// floodEndpoint registers a handler shaped like the production one:
+// it pushes payloads at the client until the connection dies.
+func floodEndpoint(path string) {
+	payload := bytes.Repeat([]byte("x"), 32*1024)
+	Endpoint(path, func(ctx context.Context, ip string, q url.Values, replies <-chan []byte, outgoing chan<- []byte, shutdown chan<- error, requestShutdown <-chan bool) {
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-requestShutdown:
+				return
+			case <-replies:
+			case <-ticker.C:
+				select {
+				case outgoing <- payload:
+				default:
+				}
+			}
+		}
+	})
+}
+
+// TestStalledClientWedgesWriterWithoutDeadline is the control: with
+// the write deadline effectively disabled (the old behavior), a
+// client that stops reading leaves the writer goroutine blocked in
+// WriteMessage forever - the messages channel stops draining and the
+// connection never tears down.
+func TestStalledClientWedgesWriterWithoutDeadline(t *testing.T) {
+	old := WriteWait
+	WriteWait = time.Hour
+	defer func() { WriteWait = old }()
+
+	floodEndpoint("/draintest-control")
+	server := httptest.NewServer(http.DefaultServeMux)
+	defer server.Close()
+	addr := strings.TrimPrefix(server.URL, "http://")
+
+	baseline := endpointGoroutines()
+	conn := stalledClient(t, addr, "/draintest-control")
+	defer conn.Close()
+
+	time.Sleep(3 * time.Second)
+	if got := endpointGoroutines(); got <= baseline {
+		t.Fatalf("expected the stalled connection's goroutines to persist without a write deadline, baseline %d, got %d", baseline, got)
+	}
+}
+
+// TestStalledClientIsReapedByWriteDeadline proves the fix: the write
+// errors out within WriteWait, the writer exits, and the whole
+// connection tears down, returning the goroutine count to baseline.
+func TestStalledClientIsReapedByWriteDeadline(t *testing.T) {
+	old := WriteWait
+	WriteWait = 500 * time.Millisecond
+	defer func() { WriteWait = old }()
+
+	floodEndpoint("/draintest-fixed")
+	server := httptest.NewServer(http.DefaultServeMux)
+	defer server.Close()
+	addr := strings.TrimPrefix(server.URL, "http://")
+
+	baseline := endpointGoroutines()
+	conn := stalledClient(t, addr, "/draintest-fixed")
+	defer conn.Close()
+
+	// The connection must be alive at first.
+	deadline := time.Now().Add(2 * time.Second)
+	for endpointGoroutines() <= baseline && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := endpointGoroutines(); got <= baseline {
+		t.Fatalf("expected the connection's goroutines to appear, baseline %d, got %d", baseline, got)
+	}
+
+	// Once the socket buffer fills, the next write must hit the
+	// deadline and tear the connection down completely.
+	deadline = time.Now().Add(30 * time.Second)
+	for endpointGoroutines() > baseline && time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+	}
+	if got := endpointGoroutines(); got > baseline {
+		t.Fatalf("stalled connection was not reaped by the write deadline: %d endpoint goroutines still running (baseline %d)", got, baseline)
+	}
+}


### PR DESCRIPTION
Per Alex: *"find out why some channels don't drain, so the program needs to be killed."* Here is the answer, and the smallest change that fixes it — 2 functional lines plus comments and tests. No new features.

## Why the channels stop draining

**`messages` (per connection).** Its drainer is the writer goroutine, and `WriteMessage` has no write deadline. A client that stops reading — backgrounded tab, phone that dropped off the network with TCP still open — blocks the writer *forever* once the kernel socket buffer fills. From that moment: the `messages` channel backs up with up to 1000 encoded rows and never drains again, the reader is parked (nothing arrives), the handler keeps running, and the connection is hijacked so no context ever fires. Nothing can reclaim it. These wedged connections accumulate with traffic until the process needs killing. The fix is `SetWriteDeadline` before each write: the write errors instead of blocking, the writer exits, and the **existing** teardown chain (cancel → handler exit → unsubscribe → close) reclaims everything. Because this service pushes rows to every subscriber every second, the write deadline alone reaps dead subscribers within seconds — no pings, no read deadlines needed.

**The heartbeat pulse.** `Pulse()` uses `http.Get` with no timeout. One hung heartbeat request wedges the minute-ticker loop in `websocket.database` permanently — pulses stop on a healthy process, and anything watching the heartbeat kills it for nothing. Bounded with a 10s client timeout.

## Proof

`lib/websocket` tests, both passing:
- `TestStalledClientWedgesWriterWithoutDeadline` — control: with the deadline disabled (old behavior), a raw-TCP client that upgrades then stops reading leaves the connection's goroutines alive indefinitely.
- `TestStalledClientIsReapedByWriteDeadline` — with the deadline, the same client's connection is torn down completely (goroutine count returns to baseline) within `WriteWait`.

## Deliberately not included

No buffering changes, no snapshot changes, no pings/read deadlines, no backfill. One residual case — a client that connects, never subscribes, and vanishes — receives no writes and so isn't reaped by this; behind Cloudflare those idle connections get closed by the proxy's idle timeout, which then unblocks the reader normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
