### PR TITLE
Fit the chart window to the data span

### DIFF
--- a/web/src/components/v2/chart.tsx
+++ b/web/src/components/v2/chart.tsx
@@ -34,9 +34,17 @@ function AssetPriceChart({
   );
   const latestPrice = data.length > 0 ? data[data.length - 1].value : basePrice;
   const priceIsAbove = latestPrice > basePrice;
-  // Trailing window sized to the campaign, so every point stays in
-  // view for the market's whole lifetime.
-  const windowSecs = Math.max(60, Math.round((ending - starting) / 1000));
+  // Liveline's window trails the live edge, so size it to the span
+  // of the data we actually have: the first available point sits at
+  // the left edge and the line stretches the full width, however
+  // little history the websocket delivered. Capped to the campaign
+  // duration, with a floor so the first ticks aren't absurdly zoomed.
+  const campaignSecs = Math.max(60, Math.round((ending - starting) / 1000));
+  const windowSecs = useMemo(() => {
+    if (data.length < 2) return 30;
+    const span = Math.ceil(data[data.length - 1].time - data[0].time);
+    return Math.min(Math.max(30, span), campaignSecs);
+  }, [data, campaignSecs]);
 
   return (
     <div style={{ height: chartHeight }}>


### PR DESCRIPTION
Fixes the graph starting midway through the window (reported by Erik with screenshots): liveline's `window` trails the live edge, and it was sized to the full campaign duration — so when the websocket only has history back to its last restart, the line occupied just the right portion of a mostly-empty axis.

Now the window is sized to the **span of the data we actually have** (clamped to the campaign duration, floored at 30s): the first available point sits at the left edge and the line stretches the full width, zooming out smoothly as the campaign accumulates data — the normal liveline look regardless of how much history the websocket delivered.

One file, `web/src/components/v2/chart.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
