### PR TITLE
websocket.database: limit + compact the snapshot buffers, bound the drains

### DIFF
--- a/cmd/websocket.database/README.md
+++ b/cmd/websocket.database/README.md
@@ -5,3 +5,12 @@ Uses a Postgres CDC to get updates to tables we send to our users over websocket
 
 Warning: this code is horrible. We partly programmed this after we had a leak with Claude
 and it over engineered it and took it down a crap path.
+
+## Memory
+
+The prices feed covers 1000+ bases; the markets use a handful. Set
+`SPN_PRICES_BASES` (comma separated, e.g. `BTC,WTIOIL,DRAM`) so the
+snapshot ring buffers only retain history for those bases — unset, the
+buffers grow toward roughly 1.3GB. Also set `GOMEMLIMIT` (standard Go
+runtime env, e.g. `GOMEMLIMIT=100MiB`) slightly under the container's
+memory limit so GC pressure degrades gracefully instead of an OOM kill.

--- a/cmd/websocket.database/buffer_test.go
+++ b/cmd/websocket.database/buffer_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// The compact priceRow must marshal to exactly the JSON shape of the
+// decoded map it replaces, so snapshot payloads are unchanged.
+func TestCompactPriceRowSameJSON(t *testing.T) {
+	created := time.Date(2026, 7, 9, 10, 0, 0, 123456000, time.UTC)
+	m := map[string]any{
+		"id":         int64(42),
+		"base":       "BTC",
+		"amount":     62000.5,
+		"created_by": created,
+	}
+	row := compactPriceRow(m)
+	if _, ok := row.(priceRow); !ok {
+		t.Fatalf("expected compact form, got %T", row)
+	}
+	got, err := json.Marshal(row)
+	if err != nil {
+		t.Fatalf("marshal compact: %v", err)
+	}
+	want, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal map: %v", err)
+	}
+	var gotV, wantV map[string]any
+	if err := json.Unmarshal(got, &gotV); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(want, &wantV); err != nil {
+		t.Fatal(err)
+	}
+	for k, w := range wantV {
+		if g, ok := gotV[k]; !ok || g != w {
+			t.Fatalf("field %q: compact %v, map %v", k, gotV[k], w)
+		}
+	}
+	if len(gotV) != len(wantV) {
+		t.Fatalf("field count differs: compact %d, map %d", len(gotV), len(wantV))
+	}
+}
+
+// Unexpected decoded types must fall back to the map unchanged.
+func TestCompactPriceRowFallback(t *testing.T) {
+	m := map[string]any{"id": "not-an-int", "base": "BTC", "amount": 1.0, "created_by": time.Now()}
+	if _, ok := compactPriceRow(m).(map[string]any); !ok {
+		t.Fatal("expected fallback to the original map")
+	}
+}
+
+// itemField must read both retained forms identically.
+func TestItemField(t *testing.T) {
+	row := priceRow{Id: 7, Base: "BTC", Amount: 1.5, CreatedBy: time.Unix(100, 0)}
+	m := map[string]any{"id": int64(7), "base": "BTC", "amount": 1.5, "created_by": time.Unix(100, 0)}
+	for _, k := range []string{"id", "base", "amount", "created_by"} {
+		rv, rok := itemField(row, k)
+		mv, mok := itemField(m, k)
+		if !rok || !mok {
+			t.Fatalf("field %q missing: row %v, map %v", k, rok, mok)
+		}
+		if rv != mv {
+			t.Fatalf("field %q differs: row %v, map %v", k, rv, mv)
+		}
+	}
+	if _, ok := itemField(row, "nope"); ok {
+		t.Fatal("unknown field must not resolve")
+	}
+}

--- a/cmd/websocket.database/main.go
+++ b/cmd/websocket.database/main.go
@@ -32,6 +32,15 @@ const (
 	EnvPublicationName       = "SPN_PUBLICATION_NAME"
 	EnvPublicationSlot       = "SPN_PUBLICATION_SLOT"
 	EnvPublicationMetricSlot = "SPN_PUBLICATION_PORT"
+
+	// EnvPricesBases optionally limits which price bases are kept in
+	// the snapshot ring buffers, comma separated. The oracle feeds
+	// rows for over a thousand bases while the markets use a handful,
+	// and retaining 4000 rows for every one of them grows the heap
+	// without bound. Live broadcasting is unaffected; only snapshot
+	// history is limited. Empty keeps the old buffer-everything
+	// behavior.
+	EnvPricesBases = "SPN_PRICES_BASES"
 )
 
 const PrivateSnapshotLookback = 4000
@@ -40,10 +49,10 @@ const PricesTable = "oracles_ninelives_prices_2"
 const PricesPartitionKey = "base"
 
 type TableContent struct {
-	Table            string           `json:"table"`
-	Content          map[string]any   `json:"content,omitempty"`
-	Snapshot         []map[string]any `json:"snapshot,omitempty"`
-	SnapshotToplevel []TableContent   `json:"snapshot_toplevel,omitempty"`
+	Table            string         `json:"table"`
+	Content          map[string]any `json:"content,omitempty"`
+	Snapshot         []any          `json:"snapshot,omitempty"`
+	SnapshotToplevel []TableContent `json:"snapshot_toplevel,omitempty"`
 	encoded          []byte
 }
 
@@ -51,9 +60,56 @@ type FilterConstraint struct {
 	Et any `json:"et"`
 }
 
+// priceRow is the compact retained form of a prices table row: one
+// small struct instead of a map[string]any and its boxed values,
+// which cost several times more per row. It marshals to the same
+// JSON shape as the decoded map.
+type priceRow struct {
+	Id        int64     `json:"id"`
+	Base      string    `json:"base"`
+	Amount    float64   `json:"amount"`
+	CreatedBy time.Time `json:"created_by"`
+}
+
+// compactPriceRow converts a decoded prices row to its compact form,
+// falling back to the map unchanged if the decoded types are ever
+// not what we expect.
+func compactPriceRow(m map[string]any) any {
+	id, ok1 := m["id"].(int64)
+	base, ok2 := m["base"].(string)
+	amount, ok3 := m["amount"].(float64)
+	createdBy, ok4 := m["created_by"].(time.Time)
+	if !ok1 || !ok2 || !ok3 || !ok4 {
+		return m
+	}
+	return priceRow{Id: id, Base: base, Amount: amount, CreatedBy: createdBy}
+}
+
+// itemField reads a field from a buffered row, which is either a
+// decoded map or a compact priceRow.
+func itemField(item any, k string) (any, bool) {
+	switch it := item.(type) {
+	case map[string]any:
+		v, ok := it[k]
+		return v, ok
+	case priceRow:
+		switch k {
+		case "id":
+			return it.Id, true
+		case "base":
+			return it.Base, true
+		case "amount":
+			return it.Amount, true
+		case "created_by":
+			return it.CreatedBy, true
+		}
+	}
+	return nil, false
+}
+
 type ringBuffer struct {
 	i     int
-	items [PrivateSnapshotLookback]map[string]any
+	items [PrivateSnapshotLookback]any
 }
 
 type partitionedBuffer struct {
@@ -71,7 +127,7 @@ func newPartitionedBuffer() *partitionedBuffer {
 	return &partitionedBuffer{buffers: make(map[string]*ringBuffer)}
 }
 
-func (pb *partitionedBuffer) insert(partitionKey string, content map[string]any) {
+func (pb *partitionedBuffer) insert(partitionKey string, content any) {
 	x := pb.buffers[partitionKey]
 	if x == nil {
 		x = &ringBuffer{}
@@ -84,10 +140,10 @@ func (pb *partitionedBuffer) insert(partitionKey string, content map[string]any)
 	x.i++
 }
 
-func (pb *partitionedBuffer) allItems() []map[string]any {
-	var out []map[string]any
+func (pb *partitionedBuffer) allItems() []any {
+	var out []any
 	for _, rb := range pb.buffers {
-		snapshot := make([]map[string]any, PrivateSnapshotLookback)
+		snapshot := make([]any, PrivateSnapshotLookback)
 		copy(snapshot, rb.items[:])
 		for _, item := range snapshot {
 			if item != nil {
@@ -186,6 +242,13 @@ func main() {
 
 	dumpChan := make(chan dumpRequest)
 
+	pricesBases := make(map[string]bool)
+	for _, b := range strings.Split(os.Getenv(EnvPricesBases), ",") {
+		if b = strings.ToUpper(strings.TrimSpace(b)); b != "" {
+			pricesBases[b] = true
+		}
+	}
+
 	go func() {
 		bufferMsgsChan := make(chan TableContent, 100*60)
 		bufferCookie := broadcast.Subscribe(bufferMsgsChan)
@@ -211,13 +274,18 @@ func main() {
 				}
 
 				partitionKey := ""
+				row := any(v.Content)
 				if v.Table == PricesTable {
 					if base, ok := v.Content[PricesPartitionKey]; ok {
 						partitionKey = fmt.Sprintf("%v", base)
 					}
+					if len(pricesBases) > 0 && !pricesBases[strings.ToUpper(partitionKey)] {
+						continue
+					}
+					row = compactPriceRow(v.Content)
 				}
 
-				pb.insert(partitionKey, v.Content)
+				pb.insert(partitionKey, row)
 
 			case req, ok := <-dumpChan:
 				if !ok {
@@ -420,14 +488,14 @@ func main() {
 									continue
 								}
 
-								var filteredItems []map[string]any
+								var filteredItems []any
 								for _, item := range tableContent.Snapshot {
 									if item == nil {
 										continue
 									}
 									include := true
 									for k, c := range tableFilter {
-										v, exists := item[k]
+										v, exists := itemField(item, k)
 										if !exists || !compareFmt(v, c.Et) {
 											include = false
 											break

--- a/lib/heartbeat/heartbeat.go
+++ b/lib/heartbeat/heartbeat.go
@@ -8,12 +8,19 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 )
 
 // EnvHeartbeatUrl to optionally send a GET to on request.
 const EnvHeartbeatUrl = "SPN_HEARTBEAT_URL"
 
 var urls = make(chan string)
+
+// client bounds the heartbeat request. The default client has no
+// timeout, so a hung request wedges the caller's pulse loop forever:
+// pulses stop even though the process is healthy, and anything
+// watching the heartbeat kills it for no reason.
+var client = &http.Client{Timeout: 10 * time.Second}
 
 func Pulse() {
 	u := <-urls
@@ -22,7 +29,7 @@ func Pulse() {
 		return
 	}
 	slog.Debug("sending a heartbeat message")
-	resp, err := http.Get(u)
+	resp, err := client.Get(u)
 	if err != nil {
 		slog.Error("error reporting to heartbeat", "err", err)
 		return

--- a/lib/websocket/websocket.go
+++ b/lib/websocket/websocket.go
@@ -12,6 +12,20 @@ import (
 
 const DeadlinePong = 3 * time.Minute
 
+// WriteWait bounds every write to the client. Without it, the writer
+// goroutine is the one place a channel stops draining: WriteMessage
+// on a client that stopped reading (or whose network vanished with
+// the TCP connection still open) blocks forever once the socket
+// buffer fills, so the messages channel backs up with encoded rows,
+// its connection never tears down, and the process accumulates these
+// wedged connections until it has to be killed. With a deadline the
+// write errors instead, the writer exits, and the whole connection
+// (goroutines, buffers, broadcast subscription) is torn down. Since
+// this service pushes rows to every subscriber continuously, a write
+// deadline alone is enough to reap dead subscribers within seconds.
+// A var, not a const, so tests can shrink it.
+var WriteWait = 30 * time.Second
+
 var websocketUpgrader = websocket.Upgrader{
 	ReadBufferSize:  4096,
 	WriteBufferSize: 4096,
@@ -129,6 +143,7 @@ func Endpoint(endpoint string, handler func(ctx context.Context, ipAddr string, 
 					if !ok {
 						return
 					}
+					websocketConn.SetWriteDeadline(time.Now().Add(WriteWait))
 					if err := websocketConn.WriteMessage(websocket.TextMessage, message); err != nil {
 						slog.Error("failed to write websocket message",
 							"ip", ipAddress,

--- a/lib/websocket/websocket_test.go
+++ b/lib/websocket/websocket_test.go
@@ -1,0 +1,139 @@
+package websocket
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// endpointGoroutines counts goroutines with a frame in this package's
+// connection machinery (reader, writer, or the upgraded handler).
+func endpointGoroutines() int {
+	buf := make([]byte, 1<<22)
+	n := runtime.Stack(buf, true)
+	count := 0
+	for _, block := range strings.Split(string(buf[:n]), "\n\n") {
+		if strings.Contains(block, "lib/websocket/websocket.go") {
+			count++
+		}
+	}
+	return count
+}
+
+// stalledClient performs a bare websocket upgrade over raw TCP and
+// then never reads again, like a client whose network vanished with
+// the TCP connection still open: the server's writes pile up until
+// the socket buffer is full.
+func stalledClient(t *testing.T, addr, path string) net.Conn {
+	t.Helper()
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	key := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x42}, 16))
+	fmt.Fprintf(conn, "GET %s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: %s\r\nSec-WebSocket-Version: 13\r\n\r\n", path, addr, key)
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read upgrade response: %v", err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("upgrade failed: %v", resp.Status)
+	}
+	return conn
+}
+
+// floodEndpoint registers a handler shaped like the production one:
+// it pushes payloads at the client until the connection dies.
+func floodEndpoint(path string) {
+	payload := bytes.Repeat([]byte("x"), 32*1024)
+	Endpoint(path, func(ctx context.Context, ip string, q url.Values, replies <-chan []byte, outgoing chan<- []byte, shutdown chan<- error, requestShutdown <-chan bool) {
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-requestShutdown:
+				return
+			case <-replies:
+			case <-ticker.C:
+				select {
+				case outgoing <- payload:
+				default:
+				}
+			}
+		}
+	})
+}
+
+// TestStalledClientWedgesWriterWithoutDeadline is the control: with
+// the write deadline effectively disabled (the old behavior), a
+// client that stops reading leaves the writer goroutine blocked in
+// WriteMessage forever - the messages channel stops draining and the
+// connection never tears down.
+func TestStalledClientWedgesWriterWithoutDeadline(t *testing.T) {
+	old := WriteWait
+	WriteWait = time.Hour
+	defer func() { WriteWait = old }()
+
+	floodEndpoint("/draintest-control")
+	server := httptest.NewServer(http.DefaultServeMux)
+	defer server.Close()
+	addr := strings.TrimPrefix(server.URL, "http://")
+
+	baseline := endpointGoroutines()
+	conn := stalledClient(t, addr, "/draintest-control")
+	defer conn.Close()
+
+	time.Sleep(3 * time.Second)
+	if got := endpointGoroutines(); got <= baseline {
+		t.Fatalf("expected the stalled connection's goroutines to persist without a write deadline, baseline %d, got %d", baseline, got)
+	}
+}
+
+// TestStalledClientIsReapedByWriteDeadline proves the fix: the write
+// errors out within WriteWait, the writer exits, and the whole
+// connection tears down, returning the goroutine count to baseline.
+func TestStalledClientIsReapedByWriteDeadline(t *testing.T) {
+	old := WriteWait
+	WriteWait = 500 * time.Millisecond
+	defer func() { WriteWait = old }()
+
+	floodEndpoint("/draintest-fixed")
+	server := httptest.NewServer(http.DefaultServeMux)
+	defer server.Close()
+	addr := strings.TrimPrefix(server.URL, "http://")
+
+	baseline := endpointGoroutines()
+	conn := stalledClient(t, addr, "/draintest-fixed")
+	defer conn.Close()
+
+	// The connection must be alive at first.
+	deadline := time.Now().Add(2 * time.Second)
+	for endpointGoroutines() <= baseline && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := endpointGoroutines(); got <= baseline {
+		t.Fatalf("expected the connection's goroutines to appear, baseline %d, got %d", baseline, got)
+	}
+
+	// Once the socket buffer fills, the next write must hit the
+	// deadline and tear the connection down completely.
+	deadline = time.Now().Add(30 * time.Second)
+	for endpointGoroutines() > baseline && time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+	}
+	if got := endpointGoroutines(); got > baseline {
+		t.Fatalf("stalled connection was not reaped by the write deadline: %d endpoint goroutines still running (baseline %d)", got, baseline)
+	}
+}


### PR DESCRIPTION
Approaches 1, 2, and 5 from the performance investigation, kept as tiny as possible. No other changes.

**1 — allowlist (the big one).** `SPN_PRICES_BASES=BTC,WTIOIL,DRAM` limits which bases the snapshot ring buffers retain. The feed carries 1000+ bases; retaining 4000 rows each is ~1.3GB steady state — the measured cause of the heap climb, the latency ramp, and the kills. Live broadcast is unaffected; unset keeps today's behavior. One conditional in the buffer goroutine.

**2 — compact rows.** Prices rows are retained as a small struct instead of a decoded `map[string]any` (several times less per row), falling back to the map if decoded types are ever unexpected. Marshals to the identical JSON shape (tested).

**5 — safety nets.** Write deadline on client writes (a stalled client can no longer wedge its writer goroutine and pin its connection forever — proven by control + fix tests) and a timeout on the heartbeat request so one hung request can't stop pulses on a healthy process. `GOMEMLIMIT=100MiB` on the deployment is recommended in the README (zero code — the Go runtime reads it natively).

**Deployment:** set `SPN_PRICES_BASES` and `GOMEMLIMIT` on the websocket.database deployment. Without the env var the allowlist is inert.

Supersedes #89 (its two lines are included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
